### PR TITLE
allowing PRs to bump the version resource

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -154,7 +154,7 @@
         tag_as_latest: if pr then false else latest,
         [if build_args != null then 'build_args']: build_args,
       },
-      [if semver != null && pr != true then 'on_success']: {
+      [if semver != null then 'on_success']: {
         put: 'version',
         params: {
           file: 'version/version',


### PR DESCRIPTION
`semver` has an option of bumpring the version with the `pre` option from `1.0.0` to `1.0.0-pr.1`. So we should allow PRs to build official pre versions