### PR TITLE
fix for go version of jsonnet

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -208,7 +208,7 @@
   // Slack Message
   slackMessage(
     type = 'success',
-    title,
+    title = 'default title',
     text = null,
     channel = '#botland',
     color = null,


### PR DESCRIPTION
Fix error for go version of jsonnet `Positional argument after a named argument is not allowed`