### PR TITLE
VPA: v1alpha1 (0.2) -> v1beta1 (0.3)

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -465,7 +465,7 @@
     },
   },
 
-  VerticalPodAutoscaler(name, namespace, app=name): $._Object('poc.autoscaling.k8s.io/v1alpha1', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
+  VerticalPodAutoscaler(name, namespace, app=name): $._Object('autoscaling.k8s.io/v1beta1', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
     local vpa = self,
     target_pod:: error 'target_pod required',
     spec: {


### PR DESCRIPTION
### This is phase 2 of this migration process.
Phase 1, which blocks this PR is [here](https://github.com/getoutreach/kube_factory/pull/328).

### Remaining to-do:
- Manually GC legacy VPAs, checkpoints, and CRDs
- Deploy new VPAs + Scale all 3 VPA components back up