### PR TITLE
Use name rather than app for pdb selector

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -650,7 +650,7 @@
       maxUnavailable: '50%',
       selector: {
         matchLabels: {
-          app: app
+          name: name
         },
       },
     },


### PR DESCRIPTION
Specifically to address this issue with server-experimental mentioned here:  https://outreach-hq.slack.com/archives/C9JBBS0MD/p1564846497351900

But generally, this allows patterns where we might want `app` to be the same for multiple deployments (to be part of the same service, for example), but we want the pdb to be independent.