### PR TITLE
DEVTOOL-93 Add maestro to basic resources

### DIFF
--- a/concourse/pipeline.libsonnet
+++ b/concourse/pipeline.libsonnet
@@ -17,6 +17,7 @@ local newPipeline(name, source_repo) = {
   slack_username:: 'concourse',
   slack_url:: '((slack-url))',
   webhook_token:: '((webhook-token))',
+  maestro_secret:: '((maestro-secret))'
 
   // Pipeline output
   resource_types_:: [],

--- a/concourse/resources.libsonnet
+++ b/concourse/resources.libsonnet
@@ -3,6 +3,16 @@
 {
   // Basic resource types
   basicResourceTypes:: {
+    maestro: {
+      name: 'maestro',
+      type: 'registry-image',
+      source: {
+        repository: 'registry.outreach.cloud/maestro-resource',
+        tag: 'latest',
+        username: $.outreach_registry_username,
+        password: $.outreach_registry_password,
+      },
+    },
     slack_message: {
       name: 'slack_message',
       type: 'registry-image',
@@ -58,6 +68,14 @@
 
   // Basic resources
   basicResources:: {
+    maestro: {
+      name: 'maestro',
+      type: 'maestro',
+      source: {
+        application: $.name,
+        secret: $.maestro_secret,
+      },
+    },
     metadata: {
       name: 'metadata',
       type: 'metadata',


### PR DESCRIPTION
Move the maestro boilerplate stuff to the BasicResources section of the library to make adoption easier.