### PR TITLE
Add helpers and slack message functions

### DIFF
--- a/concourse/helpers.libsonnet
+++ b/concourse/helpers.libsonnet
@@ -1,0 +1,88 @@
+// Outreach-specific helpers for concourse
+
+{
+  appClusters: [
+    {
+      name: 'staging.us-east-2',
+      env: 'staging',
+      passed: null
+    },
+    {
+      name: 'staging.us-west-2',
+      env: 'staging',
+      passed: ['Deploy staging.us-east-2']
+    },
+    {
+      name: 'production.us-west-2',
+      env: 'production',
+      passed: ['Deploy staging.us-west-2']
+    },
+    {
+      name: 'production.us-west-2',
+      env: 'production',
+      passed: ['Deploy production.us-west-2']
+    },
+  ],
+  appBentos: [
+    {
+      name: 'staging1a',
+      cluster: 'staging.us-east-2',
+      channel: 'white',
+      passed: null
+    },
+    {
+      name: 'staging2',
+      cluster: 'staging.us-west-2',
+      channel: 'red',
+      passed: ['Deploy staging1a']
+    },
+    {
+      name: 'app1d',
+      cluster: 'production.us-west-2',
+      channel: 'orange',
+      passed: ['Deploy staging2']
+    },
+    {
+      name: 'app1e',
+      cluster: 'production.us-west-2',
+      channel: 'amber',
+      passed: ['Deploy app1d']
+    },
+    {
+      name: 'app1b',
+      cluster: 'production.us-west-2',
+      channel: 'yellow',
+      passed: ['Deploy app1e']
+    },
+    {
+      name: 'app1a',
+      cluster: 'production.us-west-2',
+      channel: 'green',
+      passed: ['Deploy app1b']
+    },
+    {
+      name: 'app1c',
+      cluster: 'production.us-west-2',
+      channel: 'green',
+      passed: ['Deploy app1a']
+    },
+    {
+      name: 'app1f',
+      cluster: 'production.us-west-2',
+      channel: 'green',
+      passed: ['Deploy app1a']
+    },
+    {
+      name: 'app2a',
+      cluster: 'production.us-east-1',
+      channel: 'green',
+      passed: ['Deploy app1b']
+    },
+    {
+      name: 'app2b',
+      cluster: 'production.us-east-1',
+      channel: 'green',
+      passed: ['Deploy app2a']
+    },
+  ],
+}

--- a/concourse/helpers.libsonnet
+++ b/concourse/helpers.libsonnet
@@ -10,17 +10,17 @@
     {
       name: 'staging.us-west-2',
       env: 'staging',
-      passed: ['Deploy staging.us-east-2']
+      passed: 'staging.us-east-2'
     },
     {
       name: 'production.us-west-2',
       env: 'production',
-      passed: ['Deploy staging.us-west-2']
+      passed: 'staging.us-west-2'
     },
     {
       name: 'production.us-west-2',
       env: 'production',
-      passed: ['Deploy production.us-west-2']
+      passed: 'production.us-west-2'
     },
   ],
   appBentos: [
@@ -34,55 +34,55 @@
       name: 'staging2',
       cluster: 'staging.us-west-2',
       channel: 'red',
-      passed: ['Deploy staging1a']
+      passed: 'staging1a'
     },
     {
       name: 'app1d',
       cluster: 'production.us-west-2',
       channel: 'orange',
-      passed: ['Deploy staging2']
+      passed: 'staging2'
     },
     {
       name: 'app1e',
       cluster: 'production.us-west-2',
       channel: 'amber',
-      passed: ['Deploy app1d']
+      passed: 'app1d'
     },
     {
       name: 'app1b',
       cluster: 'production.us-west-2',
       channel: 'yellow',
-      passed: ['Deploy app1e']
+      passed: 'app1e'
     },
     {
       name: 'app1a',
       cluster: 'production.us-west-2',
       channel: 'green',
-      passed: ['Deploy app1b']
+      passed: 'app1b'
     },
     {
       name: 'app1c',
       cluster: 'production.us-west-2',
       channel: 'green',
-      passed: ['Deploy app1a']
+      passed: 'app1a'
     },
     {
       name: 'app1f',
       cluster: 'production.us-west-2',
       channel: 'green',
-      passed: ['Deploy app1a']
+      passed: 'app1a'
     },
     {
       name: 'app2a',
       cluster: 'production.us-east-1',
       channel: 'green',
-      passed: ['Deploy app1b']
+      passed: 'app1b'
     },
     {
       name: 'app2b',
       cluster: 'production.us-east-1',
       channel: 'green',
-      passed: ['Deploy app2a']
+      passed: 'app2a'
     },
   ],
 }

--- a/concourse/pipeline.libsonnet
+++ b/concourse/pipeline.libsonnet
@@ -3,6 +3,7 @@
 
 local resources = import 'resources.libsonnet';
 local templates = import 'templates.libsonnet';
+local helpers = import 'helpers.libsonnet';
 
 local newPipeline(name, source_repo) = {
   // Configuration values

--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -429,4 +429,31 @@
         } + params,
       },
     ]),
+  deploymentStartSlackMessage(name)::
+    $.slackMessage(
+      channel = '#deployments',
+      type = 'notice',
+      title = ':airplane_departure: %s deployment is starting...' % [name],
+      inputs = [
+        $.slackInput(title = 'Deployment', text = name),
+      ],
+    ),
+  deploymentSuccessfulSlackMessage(name)::
+    $.slackMessage(
+      channel = '#deployments',
+      type = 'success',
+      title = ':airplane_arriving: %s deployment succeeded! :successkid:' % [name],
+      inputs = [
+        $.slackInput(title = 'Deployment', text = name),
+      ],
+    ),
+  deploymentFailedSlackMessage(name)::
+    $.slackMessage(
+      channel = '#deployments',
+      type = 'failure',
+      title = ":boom: %s deployment failed..." % [name],
+      inputs = [
+        $.slackInput(title = 'Deployment', text = name),
+      ],
+    )
 }


### PR DESCRIPTION
This adds 2 things:
1. A set of functions for basic slack messages (deployment start, deployment successful, deployment failed) to make those single lines in a pipeline.jsonnet file.  We seem to be using the same block of code for these most of the time, so I just used that.
2. A set of arrays containing basic kv pairs for bentos and clusters.  This _might_ be assuming too much (in which case we just not use them), but it seems helpful for microservices whose configuration only differs by properties inherent to the cluster/bento it's being deployed to.  If that proves to be untrue in most cases, we can drop this, but signs point to it being useful.