### PR TITLE
PLAT-2433 Migrate VPA spec definition to use API v1beta2

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -494,6 +494,11 @@
     local vpa = self,
     target:: error 'target required',
     spec: {
+      // Because this is a transitional patch to VPA we still require the spec.selector to not be empty.
+      // We can remove this after we upgrade VPA from 0.4.1 to 0.5.X or greater.
+      selector: {
+        matchLabels: {},
+      },
       targetRef: $.CrossVersionObjectReference(vpa.target),
 
       updatePolicy: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -502,7 +502,7 @@
       targetRef: $.CrossVersionObjectReference(vpa.target),
 
       updatePolicy: {
-        updateMode: "Auto",
+        updateMode: "Initial",
       },
     },
   },

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -490,7 +490,7 @@
     },
   },
 
-  VerticalPodAutoscaler(name, namespace, app=name): $._Object('autoscaling.k8s.io/v1beta1', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
+  VerticalPodAutoscaler(name, namespace, app=name): $._Object('autoscaling.k8s.io/v1beta2', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
     local vpa = self,
     target:: error 'target required',
     spec: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -492,10 +492,12 @@
 
   VerticalPodAutoscaler(name, namespace, app=name): $._Object('autoscaling.k8s.io/v1beta1', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
     local vpa = self,
-    target_pod:: error 'target_pod required',
+    target:: error 'target required',
     spec: {
-      selector: {
-        matchLabels: vpa.target_pod.metadata.labels,
+      targetRef: $.CrossVersionObjectReference(vpa.target),
+
+      updatePolicy: {
+        updateMode: "Auto",
       },
     },
   },


### PR DESCRIPTION
https://outreach-io.atlassian.net/browse/PLAT-2433

This is the definition update for vertical-pod-autoscalers to reduce the enormous amount of error logs being generated because we're targeting pods on the deprecated `matchLabel` rather than `targetRef`.

The spec change is required to upgrade VPA: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.5.0

I believe I am going to have to open PRs to give each VPA a `target`, and so this PR may be the first of many.