### PR TITLE
Let namespace be null

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -634,7 +634,7 @@
     subjects_:: [],
     subjects: [{
       kind: o.kind,
-      namespace: o.metadata.namespace,
+      namespace: if std.objectHas(o.metadata, "namespace") then o.metadata.namespace else null,
       name: o.metadata.name,
     } for o in self.subjects_],
 


### PR DESCRIPTION
ClusterRoleBinding objects don't require a namespace, so rather than forcing `namespace: null` on objects, lets just check if its set or not.