### PR TITLE
FIX: remove version:every

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -30,7 +30,6 @@
       get: source,
       [if trigger != null then 'trigger']: trigger,
       [if passed != null then 'passed']: passed,
-      [if pr then 'version']: 'every',
     },
 
   // Template for running tasks from repo


### PR DESCRIPTION
This removes the `version: every` argument for the PR resource. With the new re-run with same inputs button it removes the need to have a way to trigger on every version.

Current behavior causes some pipelines to hang on already merged PRs, specifically the `proxysql` repo is running tests against the incorrect PR. This fix was tested and resulted in the appropriate behavior.