### PR TITLE
feat/new annotations for cert-manager

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -38,6 +38,7 @@ k + kubecfg {
     },
     local tlsAnnotations = {
       'certmanager.k8s.io/acme-http01-edit-in-place': 'false',
+      'acme.cert-manager.io/http01-edit-in-place': 'false',
       'ingress.kubernetes.io/force-ssl-redirect': 'true',
       'kubernetes.io/tls-acme': 'true',
       'contour.heptio.com/tls-minimum-protocol-version': '1.2',


### PR DESCRIPTION
This prepares us for an upgrade for cert-manager in the future. We're going to need to migrate to the new annotations.

Source: https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/