### PR TITLE
Remove staging2 & staging.us-west-2 references from helpers

### DIFF
--- a/concourse/helpers.libsonnet
+++ b/concourse/helpers.libsonnet
@@ -8,14 +8,9 @@
       passed: null
     },
     {
-      name: 'staging.us-west-2',
-      environment: 'staging',
-      passed: 'staging.us-east-2'
-    },
-    {
       name: 'production.us-west-2',
       environment: 'production',
-      passed: 'staging.us-west-2'
+      passed: 'staging.us-east-2'
     },
     {
       name: 'production.us-east-1',
@@ -39,14 +34,6 @@
       region: 'us-east-2',
       passed: null
     },
-    {
-      name: 'staging2',
-      cluster: 'staging.us-west-2',
-      channel: 'white',
-      environment: 'staging',
-      region: 'us-west-2',
-      passed: 'staging1a'
-    },
   ],
   appBentos():: [
     {
@@ -58,20 +45,12 @@
       passed: null
     },
     {
-      name: 'staging2',
-      cluster: 'staging.us-west-2',
-      channel: 'white',
-      environment: 'staging',
-      region: 'us-west-2',
-      passed: 'staging1a'
-    },
-    {
       name: 'app1d',
       cluster: 'production.us-west-2',
       channel: 'orange',
       environment: 'production',
       region: 'us-west-2',
-      passed: 'staging2'
+      passed: 'staging1a'
     },
     {
       name: 'app1e',


### PR DESCRIPTION
This change removes the staging2 & staging.us-west-2 references from
these here helpers as we are removing both staging2 & staging.us-west-2
from our infrastructure.

NOTE: Please do not merge until the staging2 decom has begun.