### PR TITLE
Add checkoutMaestroVersion function for pipelines

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -539,4 +539,17 @@
   },
   maestroActionableVersion(name, deploy_name):: $.maestroResource(name, deploy_name, 'actionable_version'),
   maestroDeployedVersion(name, deploy_name):: $.maestroResource(name, deploy_name, 'deployed_version'),
+  checkoutMaestroVersion(maestro_resource_name):: $.newInlineTask(
+    "Checkout Maestro Version",
+    [{name: 'source'}, {name: maestro_resource_name}],
+    [
+      |||
+        set -euf -o pipefail
+        maestro_version=$(cat ./%s/version)
+        cd source
+        git checkout $maestro_version
+      ||| % [maestro_resource_name]
+    ],
+    [{name: 'source'}],
+  ),
 }


### PR DESCRIPTION
Manually tested this in a pipeline and confirmed that it checks out the specified version and that overwriting the source works as intended.