### PR TITLE
feat(concourse): allow overriding the head branch

### DIFF
--- a/concourse/pipeline.libsonnet
+++ b/concourse/pipeline.libsonnet
@@ -5,10 +5,11 @@ local resources = import 'resources.libsonnet';
 local templates = import 'templates.libsonnet';
 local helpers = import 'helpers.libsonnet';
 
-local newPipeline(name, source_repo) = {
+local newPipeline(name, source_repo, branch="master") = {
   // Configuration values
   name:: name,
   source_repo:: source_repo,
+  branch:: branch,
   github_key:: '((github-key))',
   github_access_token:: '((github-access-token))',
   outreach_registry_username:: '((outreach-registry-username))',

--- a/concourse/resources.libsonnet
+++ b/concourse/resources.libsonnet
@@ -144,7 +144,7 @@
       type: 'git',
       source: {
         uri: 'git@github.com:' + $.source_repo + '.git',
-        branch: 'master',
+        branch: $.branch,
         private_key: $.github_key,
       },
       webhook_token: $.webhook_token,


### PR DESCRIPTION
**What this PR does**: This PR adds support to our concourse `source` resource to allow configuring the base branch, this allows us to continue support repositories with a `main` branch.
