### PR TITLE
add updated contour annotation

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -42,6 +42,7 @@ k + kubecfg {
       'ingress.kubernetes.io/force-ssl-redirect': 'true',
       'kubernetes.io/tls-acme': 'true',
       'contour.heptio.com/tls-minimum-protocol-version': '1.2',
+      'projectcontour.io/tls-minimum-protocol-version': '1.2',
     },
 
     metadata+: {


### PR DESCRIPTION
Contour 1.0 requires the updated `projectcontour.io/` annotation. In EKS we're utilizing a version of Contour that has deprecated the old annotations, and in Kops clusters we're using a version of Contour that's so old this isn't recognized. 

This shouldn't cause any issues -- I will test this in staging and EKS to validate.