### PR TITLE
update ContourIngress to work with EKS

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -2,8 +2,6 @@ local k = import 'kube.libsonnet';
 local kubecfg = import 'kubecfg.libsonnet';
 
 k + kubecfg {
-  // DEPRECATED: will be removing the cluster key
-  cluster: import 'cluster.libsonnet',
   ContourIngress(
     name,
     namespace,
@@ -15,10 +13,10 @@ k + kubecfg {
     serviceName=name,
     servicePort='http',
     tlsSecret=null,
+    cluster_info=null,
   ): self.Ingress(name, namespace, app=app) {
     local this = self,
-    local cluster = import 'cluster.libsonnet',
-
+    local cluster = if cluster_info == null then import 'cluster.libsonnet' else cluster_info,
     host:: '%s.%s.%s' % [subdomain, cluster.global_name, ingressDomain],
     local target = '%s.%s.%s' % [contour, cluster.global_name, contourDomain],
     local rule = {


### PR DESCRIPTION
Testing this with the EKS pattern with a vault.jsonnet

Command:
```
kubecfg show addons/vault/vault.jsonnet \
-V cluster_name=cor-test2 \
-V cluster_region=us-east-2 \
-V cluster_environment=test \
-V cluster_fqdn=cor-test2.us-east-2.aws.outreach.cloud \
-V cluster_dns_zone=cor.outreach.cloud \
-V cluster_cloud_provider=aws
```

Returns: 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/target: contour.test.us-east-2.outreach.cloud
    kubernetes.io/ingress.class: contour
  labels:
    app: vault-a-tls
    name: vault-a
  name: vault-a
  namespace: vault
spec:
  rules:
  - host: vault-a.test.us-east-2.outreach.cloud
    http:
      paths:
      - backend:
          serviceName: vault-a
          servicePort: http
```

And with a vault.jsonnet utilizing the clusters.yaml
Command:
```
kubecfg show addons/vault/vault.jsonnet \
--ext-str-file cluster.yaml=/app/config/clusters/eevee.yaml --jpath /app --jurl http://k8s-clusters.outreach.cloud/
-V cluster_name=cor-test2 \
-V cluster_region=us-east-2 \
-V cluster_environment=test \
-V cluster_fqdn=cor-test2.us-east-2.aws.outreach.cloud \
-V cluster_dns_zone=cor.outreach.cloud \
-V cluster_cloud_provider=aws \
-V cluster=staging.us-east-2
```
Returns:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/target: contour.staging.us-east-2.outreach.cloud
    kubernetes.io/ingress.class: contour
  labels:
    app: vault-a-tls
    name: vault-a
  name: vault-a
  namespace: vault
spec:
  rules:
  - host: vault-a.staging.us-east-2.outreach.cloud
    http:
      paths:
      - backend:
          serviceName: vault-a
          servicePort: http
```