### PR TITLE
Remove caching path for image build task

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -213,7 +213,6 @@
           } + params + build_args,
           inputs: [{name: source}, {name: 'version', optional: true}],
           outputs: [{name: 'image'}],
-          caches: [{path: 'cache'}],
           run: {
             path: '/bin/bash',
             args: [


### PR DESCRIPTION
Removing the cache path for the image build path disables caching (see the resource code here: https://github.com/vito/oci-build-task).  I'm doing this at the library level because:
 - We shouldn't be building anything in concourse other than `outreach-docker` anyway
 - Setting this in the library and then unsetting it for all of those tasks seems dumb
 - Any builds we do want to make sure that we get the latest version of everything anyway, since this is how we handle patches.  If we use this for something else in the future (which we shouldn't) and we want caching (which seems like a bad idea), we should explicitly turn it on and have to justify doing so.