### PR TITLE
added databsae credential objects

### DIFF
--- a/kubernetes/database-credentials.libsonnet
+++ b/kubernetes/database-credentials.libsonnet
@@ -1,0 +1,17 @@
+local k = import 'kubernetes/kube.libsonnet';
+{
+  DatabaseCredential(name, namespace): k._Object('databases.outreach.io/v1', 'DatabaseCredential', name, namespace) {
+    username:: error 'username is required',
+    local this = self,
+    spec: {
+      username: this.username,
+      grants: this.grants,
+    },
+  },
+  Grant(privilege, pattern): { 
+    assert privilege != "": 'privilege is required',
+    assert  pattern != "": 'pattern is required',
+    privilege: privilege,
+    pattern: pattern,
+  },
+}


### PR DESCRIPTION
Example:
```
❯ kubecfg --jurl http://k8s-clusters.outreach.cloud/  --jurl file:///Users/davidboon/Projects/jsonnet-libs/ show online-schema-change-coordinator.database_user.jsonnet
---
apiVersion: databases.outreach.io/v1
kind: DatabaseCredential
metadata:
  annotations: {}
  labels:
    app: test
    name: test
  name: test
spec:
  grants:
  - pattern: '*.*'
    privilege: REPLICATION CLIENT, REPLICATION SLAVE, PROCESS
  username: this_is_a_username
```
