### PR TITLE
QSS-720 making privileges an array

### DIFF
--- a/kubernetes/database-credentials.libsonnet
+++ b/kubernetes/database-credentials.libsonnet
@@ -8,10 +8,10 @@ local k = import 'kubernetes/kube.libsonnet';
       grants: this.grants,
     },
   },
-  Grant(privilege, pattern): { 
-    assert privilege != "": 'privilege is required',
+  Grant(privileges, pattern): { 
+    assert std.length(privileges) > 0: 'privileges(array of string) is required',
     assert  pattern != "": 'pattern is required',
-    privilege: privilege,
+    privileges: privileges,
     pattern: pattern,
   },
 }


### PR DESCRIPTION
this change makes it easier to skip grants that might be otherwise hidden in a string, and skipping one embedded privilege is more difficult programmatically 