### PR TITLE
fix: added vault secret ad pre-sync hook

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -759,6 +759,11 @@
   VaultSecret(name, namespace): $._Object('secrets.outreach.io/v1alpha1', 'VaultSecret', name, namespace=namespace) {
     vaultPath_:: error 'vaultPath_ is required',
     local this = self,
+    metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/hook: PreSync': '',
+        },
+    },
     spec: {
       reconciled: false,
       vaultPath: this.vaultPath_,

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -761,7 +761,7 @@
     local this = self,
     metadata+: {
         annotations+: {
-          'argocd.argoproj.io/hook: PreSync': '',
+          'argocd.argoproj.io/hook:': 'PreSync',
         },
     },
     spec: {


### PR DESCRIPTION
made all vaultSecret CRD pre-sync so secrets are populated when pods are deployed