### PR TITLE
Adding a new function to help wait for db provisioning

### DIFF
--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -41,7 +41,7 @@ local k = import 'kubernetes/kube.libsonnet';
       instance_class: if std.objectHas(this.instance_classes, namespace) then this.instance_classes[namespace] else this.instance_classes['default'],
     },
   },
-  WaitForDatabaseProvisioning(database_cluster_name, namespace):  k._Object('databases.outreach.io/v1', 'PostgresqlDatabaseCluster', name=database_cluster_name, namespace=namespace) {
+  WaitForDatabaseProvisioning(database_cluster_name, app, namespace):  k._Object('databases.outreach.io/v1', 'PostgresqlDatabaseCluster', name=database_cluster_name, app=app, namespace=namespace) {
     task: "Wait for database to deploy",
     local this = self,
     kubernetes_cluster_name:: error 'k8 cluster name is required',

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -44,7 +44,7 @@ local k = import 'kubernetes/kube.libsonnet';
   WaitForDatabaseProvisioning(database_cluster_name, namespace):  k._Object('databases.outreach.io/v1', 'PostgresqlDatabaseCluster', name=database_cluster_name, namespace=namespace) {
     task: "Wait for database to deploy",
     local this = self,
-    bento:: error 'bento is required',
+    kubernetes_cluster_name:: error 'k8 cluster name is required',
     config: {
       platform: 'linux',
       image_resource: $.basicResources.task_image + { name:: null },
@@ -57,10 +57,11 @@ local k = import 'kubernetes/kube.libsonnet';
           |||
             set -euf -o pipefail
             DATABASECLUSTERNAME=%s
-            BENTO=%s
+            K8SCLUSTER=%s
             NAMESPACE=%s
+            kubectl config use-context $K8SCLUSTER
             kubectl wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
-          ||| % [this.database_cluster_name, this.bento, this.namespace],
+          ||| % [this.database_cluster_name, this.kubernetes_cluster_name, this.namespace],
         ],
       },
     },


### PR DESCRIPTION
This is part of QSS-813. The PR adds a new function to help wait for the database to provision, .i.e the CR to be ready. The main use case here is for devs to wait for this step in their concourse pipeline after calling $.PostgresqlDatabaseCluster (which only creates the CR, the dpo will reconcile and then mark the CR as ready once its created on AWS). By waiting, we ensure that when the go service consuming the db starts up, the database is actually provisioned and ready.