### PR TITLE
feat: update contour ingress annotation

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -39,7 +39,7 @@ k + kubecfg {
       'acme.cert-manager.io/http01-edit-in-place': 'false',
       'ingress.kubernetes.io/force-ssl-redirect': 'true',
       'kubernetes.io/tls-acme': 'true',
-      'contour.heptio.com/tls-minimum-protocol-version': '1.2',
+      'projectcontour.io/tls-minimum-protocol-version': '1.2',
     },
 
     metadata+: {


### PR DESCRIPTION
On the tin. 1.0.0+ deprecates the contour.heptio.com in favor of projectcontour.io