### PR TITLE
fix: Make sure kubeconfig gets passed in for WaitForDatabaseProvisioning

### DIFF
--- a/concourse/resources.libsonnet
+++ b/concourse/resources.libsonnet
@@ -114,6 +114,16 @@
         password: $.gcr_registry_password,
       },
     },
+    db_deploy: {
+      name: 'db_deploy',
+      type: 'registry-image',
+      source: {
+        repository: 'gcr.io/outreach-docker/concourse/k8s-deploy-resource',
+        tag: 'latest',
+        username: $.gcr_registry_username,
+        password: $.gcr_registry_password,
+      },
+    },
   },
 
   // Basic resources
@@ -216,6 +226,14 @@
     k8s_deploy: {
       name: 'k8s_deploy',
       type: 'k8s_deploy',
+      source: {
+        vault_url: 'https://vault.outreach.cloud',
+        vault_skip_verify: false,
+      },
+    },
+    db_deploy: {
+      name: 'db_deploy',
+      type: 'db_deploy',
       source: {
         vault_url: 'https://vault.outreach.cloud',
         vault_skip_verify: false,

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -73,8 +73,8 @@ local resources = import 'resources.libsonnet';
             DATABASECLUSTERNAME=%s
             K8SCLUSTER=%s
             NAMESPACE=%s
-            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
-            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
+            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=3600s
+            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=3600s
           ||| % [database_cluster_name, this.kubernetes_cluster_name, namespace],
         ],
       },

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -53,7 +53,7 @@ local resources = import 'resources.libsonnet';
     config: {
       platform: 'linux',
       image_resource: {
-        name: 'task_image',
+        name: 'kubectl_task_image',
         type: 'registry-image',
         source: {
           repository: 'gcr.io/outreach-docker/alpine/tools',
@@ -62,7 +62,7 @@ local resources = import 'resources.libsonnet';
           password: this.gcr_registry_password,
         },
       },
-      inputs: [{ name: 'metadata' }, { name: 'source' }],
+      inputs: [{ name: 'metadata' }, { name: 'source' }, { name: 'kubeconfig' }],
       outputs: [],
       run: {
         path: '/bin/bash',
@@ -73,8 +73,8 @@ local resources = import 'resources.libsonnet';
             DATABASECLUSTERNAME=%s
             K8SCLUSTER=%s
             NAMESPACE=%s
-            kubectl config use-context $K8SCLUSTER
-            kubectl wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
+            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
+            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready
           ||| % [database_cluster_name, this.kubernetes_cluster_name, namespace],
         ],
       },

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -73,8 +73,8 @@ local resources = import 'resources.libsonnet';
             DATABASECLUSTERNAME=%s
             K8SCLUSTER=%s
             NAMESPACE=%s
-            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=3600s
-            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=3600s
+            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=1800s
+            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=1800s
           ||| % [database_cluster_name, this.kubernetes_cluster_name, namespace],
         ],
       },


### PR DESCRIPTION
Making sure kubeconfig gets passed into the wait step containers. Also adding a timeout of 30 min for db provisioning(normally takes 15-20 min for provisioning to complete).

[QSS-813]



[QSS-813]: https://outreach-io.atlassian.net/browse/QSS-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ