### PR TITLE
fix: use stub_name as global_name for ngb

### DIFF
--- a/kubernetes/cluster.libsonnet
+++ b/kubernetes/cluster.libsonnet
@@ -2,5 +2,5 @@ local kubecfg = import 'kubecfg.libsonnet';
 
 kubecfg.parseYaml(importstr 'clusters.yaml')[0][std.extVar('cluster')] {
   fqdn: '%s.%s.%s' % [self.global_name, self.cloud_provider, self.dns_zone],
-  global_name: '%s.%s' % [self.environment, self.region],
+  global_name: if std.objectHas(self, 'stub_name') then self.stub_name else '%s.%s' % [self.environment, self.region],
 }


### PR DESCRIPTION
NGB needs the global_name as "{cluster_name}.{region}" but KOPS does need "{environment}.{region}". so we are introducing a new var "stub_name" which is defined in S3 for NGB 
https://github.com/getoutreach/ngb-terraform-modules/commit/f4e67892565d52ea1d10db4b2979f75ed83fc0c2
