### PR TITLE
chore(VaultSecret): change from hook to sync-wave

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -779,7 +779,8 @@
     local this = self,
     metadata+: {
       annotations+: {
-        'argocd.argoproj.io/hook': 'PreSync',
+        // https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#how-do-i-configure-waves
+        'argocd.argoproj.io/sync-wave': '-5',
       },
     },
     spec: {


### PR DESCRIPTION
Putting the VaultSecret as a negative sync-wave will cause all VaultSecret objects to be deployed before anything else. 

This should work until we can patch the vault-secret-operator and have a status showing that the hook completed.