### PR TITLE
fix(database): Adding a helper function to wait for db provisioning in argocd

### DIFF
--- a/kubernetes/cluster.libsonnet
+++ b/kubernetes/cluster.libsonnet
@@ -1,6 +1,6 @@
 local kubecfg = import 'kubecfg.libsonnet';
 
-kubecfg.parseYaml(importstr 'clusters.yaml')[0][std.extVar('cluster')] {
-  fqdn: '%s.%s.%s' % [self.global_name, self.cloud_provider, self.dns_zone],
-  global_name: if std.objectHas(self, 'stub_name') then self.stub_name else '%s.%s' % [self.environment, self.region],
-}
+// kubecfg.parseYaml(importstr 'clusters.yaml')[0][std.extVar('cluster')] {
+//   fqdn: '%s.%s.%s' % [self.global_name, self.cloud_provider, self.dns_zone],
+//   global_name: if std.objectHas(self, 'stub_name') then self.stub_name else '%s.%s' % [self.environment, self.region],
+// }

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -100,5 +100,24 @@ local resources = import 'resources.libsonnet';
         ],
       },
     },
+    WaitForDatabaseProvisioningArgoCD(database_cluster_name, app, namespace):: {
+    task: 'Wait for database to deploy',
+    local this = self,
+    kubernetes_cluster_name:: error 'k8 cluster name is required',
+
+    name: 'kubectl_wait_database_task',
+    script: {
+      image: 'gcr.io/outreach-docker/alpine/tools:latest',
+      command: ['bash'],
+      source: |||
+            set -euf -o pipefail
+            DATABASECLUSTERNAME=%s
+            K8SCLUSTER=%s
+            NAMESPACE=%s
+            echo kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=1800s
+            kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=1800s
+          ||| % [database_cluster_name, this.kubernetes_cluster_name, namespace],
+      },
+    },
   },
 }

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -100,25 +100,26 @@ local resources = import 'resources.libsonnet';
         ],
       },
     },
-    WaitForDatabaseProvisioningArgoCD(database_cluster_name, app, namespace): k.Job(name='kubectl_wait_database_script', app=app, namespace=namespace){
-      local this = self,
-      kubernetes_cluster_name:: error 'k8 cluster name is required',
-      local job = self,
-      spec: {
-        template: {
-          spec: {
-            containers: [{
-              name: 'kubectl_wait_database_script',
-              image: 'gcr.io/outreach-docker/alpine/tools:latest',
-              command: 
-              [
-              '/bin/bash',
-              |||
-                kubectl --kubeconfig ./kubeconfig/config --context $K8SCLUSTER wait -n $NAMESPACE postgresqldatabaseclusters.databases.outreach.io/$DATABASECLUSTERNAME --for=condition=Ready --timeout=1800s
-              ||| % [database_cluster_name, this.kubernetes_cluster_name, namespace],
-              ],
-            }],
-          },
+  },
+  WaitForDatabaseProvisioningArgoCD(database_cluster_name, app, namespace): k.Job(name='kubectl-wait-database-script', app=app, namespace=namespace){
+    local this = self,
+    kubernetes_cluster_name:: error 'k8 cluster name is required',
+    local job = self,
+    spec: {
+      template: {
+        restartPolicy: 'Never',
+        spec: {
+          containers: [{
+            name: 'kubectl-wait-database-script',
+            image: 'gcr.io/outreach-docker/alpine/tools:latest',
+            command: 
+            [
+            '/bin/bash',
+            |||
+              kubectl --kubeconfig ./kubeconfig/config --context %s wait -n %s postgresqldatabaseclusters.databases.outreach.io/%s --for=condition=Ready --timeout=1800s
+            ||| % [this.kubernetes_cluster_name, namespace, database_cluster_name],
+            ],
+          }],
         },
       },
     },

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -101,7 +101,6 @@ local resources = import 'resources.libsonnet';
       },
     },
     WaitForDatabaseProvisioningArgoCD(database_cluster_name, app, namespace):: {
-    task: 'Wait for database to deploy',
     local this = self,
     kubernetes_cluster_name:: error 'k8 cluster name is required',
 

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -104,7 +104,7 @@ local resources = import 'resources.libsonnet';
     local this = self,
     kubernetes_cluster_name:: error 'k8 cluster name is required',
 
-    name: 'kubectl_wait_database_task',
+    name: 'kubectl_wait_database_script',
     script: {
       image: 'gcr.io/outreach-docker/alpine/tools:latest',
       command: ['bash'],


### PR DESCRIPTION
This adds a WaitForDatabaseProvisioningArgoCD helper method that allows us to wait for db provisioning in ArgoCD pipeline, the existing method doesn't work as the expected format is different for argocd