### PR TITLE
chore: update contour annotation

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -39,7 +39,7 @@ k + kubecfg {
       'acme.cert-manager.io/http01-edit-in-place': 'false',
       'ingress.kubernetes.io/force-ssl-redirect': 'true',
       'kubernetes.io/tls-acme': 'true',
-      'contour.heptio.com/tls-minimum-protocol-version': '1.2',
+      'projectcontour.io/tls-minimum-protocol-version': '1.2',
     },
 
     metadata+: {


### PR DESCRIPTION
contour.heptio.com is a deprecated annotation as of contour 1.0.0.