### PR TITLE
feat(discovery): add discovery client

### DIFF
--- a/kubernetes/discovery.libsonnet
+++ b/kubernetes/discovery.libsonnet
@@ -1,0 +1,16 @@
+// Client for interacting with discovery in jsonnet.
+// Requires kubecfg --jurl https://discovery.outreach.cloud/ (must be before github, which 400s)
+// Types: https://github.com/getoutreach/services/tree/main/pkg/discovery/web
+{
+  // GetBentos returns a []web.Bento
+  GetBentos():: std.parseJson(importstr '/discovery/v1/bentos').bentos,
+
+  // GetChannels returns a []web.Channel
+  GetChannels():: std.parseJson(importstr '/discovery/v1/channels').channels,
+
+  // GetBento returns a web.Bento from a given bento name
+  GetBento(name):: std.filter(function(b) b.name == name, self.GetBentos()),
+
+  // GetChannel returns a web.Channel from a given channel name
+  GetChannel(name):: std.filter(function(b) b.name == name, self.GetChannels()),
+}


### PR DESCRIPTION
**What this PR does**: This PR adds a new `discovery.libsonnet` that can be used to talk to [discovery](https://github.com/getoutreach/discovery) in our jsonnet files to get information about a given bento/channel at runtime.

**Depends on**: https://github.com/getoutreach/discovery/pull/41