### PR TITLE
fix: change argocd hook for job

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -581,7 +581,8 @@
     local job = self,
     metadata+: {
       annotations+: {
-        'argocd.argoproj.io/hook': 'PreSync',
+        'argocd.argoproj.io/hook': 'Sync',
+        'argocd.argoproj.io/sync-wave': '-3',
       },
     },
     spec: {


### PR DESCRIPTION
change the hook from PreSync to Sync for jobs as some jobs requires secrets from Vault which is pulled in Sync mode with Wave -5. 