### PR TITLE
fix(argocd): option to report maestro and opslevel

### DIFF
--- a/kubernetes/argo.libsonnet
+++ b/kubernetes/argo.libsonnet
@@ -239,11 +239,16 @@ local argocdNamespace = 'argocd';
     repo_name_:: std.split(this.repo_, '/')[std.length(std.split(this.repo_, '/')) - 1],
     source_path_:: std.join('/', std.slice(std.split(this.path_, '/'), 0, std.length(std.split(this.path_, '/')) - 1, 1)),
     env_:: {},
-
+    report_maestro_:: true,
+    report_opslevel_:: true,
     spec: {
       template: {
         metadata: {
           name: '%s--{{ name }}' % name,
+          annotations+: {
+            [if this.report_maestro_ then 'notifications.argoproj.io/subscribe.on-deployed.maestro']: '',
+            [if this.report_opslevel_ then 'notifications.argoproj.io/subscribe.on-deployed.opslevel']: '',
+          },
         },
         spec: {
           destination: {

--- a/kubernetes/argo.libsonnet
+++ b/kubernetes/argo.libsonnet
@@ -13,7 +13,14 @@ local argocdNamespace = 'argocd';
     repo_name_:: std.split(this.repo_, '/')[std.length(std.split(this.repo_, '/')) - 1],
     source_path_:: std.join('/', std.slice(std.split(this.path_, '/'), 0, std.length(std.split(this.path_, '/')) - 1, 1)),
     env_:: {},
-
+    report_maestro_:: true,
+    report_opslevel_:: true,
+    metadata+: {
+      annotations+: {
+        [if this.report_maestro_ then 'notifications.argoproj.io/subscribe.on-deployed.maestro']: '',
+        [if this.report_opslevel_ then 'notifications.argoproj.io/subscribe.on-deployed.opslevel']: '',
+      },
+    },
     spec: {
       destination: {
         namespace: this.namespace_,


### PR DESCRIPTION
default true for report_maestro_ and report_opslevel_  as most of the cases are non-bootstrap apps which are required to report deployment status to maestro and opslevel.