### PR TITLE
fix: create DPO CR before VSO

### DIFF
--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -52,6 +52,12 @@ local resources = import 'resources.libsonnet';
     cluster_parameters:: {
       default: [],
     },
+    metadata+: {
+      annotations+: {
+        // DPO CR must be created before vault-secret-operator (which has sync wave-value of -5)
+        'argocd.argoproj.io/sync-wave': '-6',
+      },
+    },
     spec: {
       provisioner: this.provisioner,
       bento: this.bento,


### PR DESCRIPTION
There are services that rely on DPO-generated VaultSecret during deployment (for legacy workflows). Because vault-secret-operator is invoked in wave-5, we need DPO's CR to be created beforehand to ensure vault secret is created to unblock VSO.