### PR TITLE
fix: alb ingress ssl explicit group order needs to be higher than 0

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -138,7 +138,7 @@ k + kubecfg {
 
       # ssl-redirect
       'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-      'alb.ingress.kubernetes.io/group.order': '0',
+      'alb.ingress.kubernetes.io/group.order': '1', // Explicit order can't be 0
     },
 
     metadata+: {


### PR DESCRIPTION
While the default is `0`, aws-load-balancer-controller errors and states the explicit value must be between 1 and 1000.