### PR TITLE
feat: update healthcheck on ALB target groups

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -159,6 +159,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s' % [cluster.region, this.host], 
         'alb.ingress.kubernetes.io/group.order': '100',
+        'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})
     },


### PR DESCRIPTION
I think it's helpful to not worry about redirects when the healthcheck defaults to `/`. That should just signal it's healthy.