### PR TITLE
fix: refactor ALB ssl redirection and add cluster wide alb option

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -107,7 +107,9 @@ k + kubecfg {
     ingressDomain='outreach.cloud',  // which domain to write dns to
     serviceName=name,
     servicePort='http',
-    createTls=false,
+    createTls=true,
+    createSSLRedirect=false,
+    clusterALB=false,
     cluster_info=null,
   ): self.Ingress(name, namespace, app=app) {
     local this = self,
@@ -116,7 +118,7 @@ k + kubecfg {
     local rule = {
       host: this.host,
       http: {
-        paths: ( if createTls != false then [ 
+        paths: ( if createSSLRedirect != false then [ 
           {
             path: '/*',
             backend: {
@@ -141,10 +143,11 @@ k + kubecfg {
     },
 
     local tlsAnnotations = {
-      # ACM MANAGER
       'acm-manager.io/enable': 'true',
+    },
 
-      # ssl-redirect
+    local sslRedirectAnnotations = {
+      'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
       'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
       'alb.ingress.kubernetes.io/group.order': '1', // Explicit order can't be 0
     },
@@ -153,15 +156,14 @@ k + kubecfg {
       annotations+: {
         # ALB ANNOTATIONS
         'kubernetes.io/ingress.class': 'alb',
-        'alb.ingress.kubernetes.io/group.name': this.host, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
+        'alb.ingress.kubernetes.io/group.name': if clusterALB != false then cluster.global_name else this.host, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
         'alb.ingress.kubernetes.io/tags': 'outreach:environment=%s,kubernetesCluster=%s,outreach:application=%s,namespace=%s' % [cluster.environment, cluster.fqdn, name, namespace], 
-        'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
+        'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s' % [cluster.region, this.host], 
-        'alb.ingress.kubernetes.io/group.order': '100',
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s' % [cluster.region, if clusterALB != false then cluster.global_name else this.host], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
-      } + (if createTls != false then tlsAnnotations else {})
+      } + (if createTls != false then tlsAnnotations else {}) + (if createSSLRedirect != false then sslRedirectAnnotations else {})
     },
     spec+: {
       rules: [


### PR DESCRIPTION
We only need the SSL redirection rule on one ingress when there are multiple ingresses grouped together, and that ingress will need to listen on port 80 so that the ALB redirect rule gets created. The others should only listen on 443.

This also enables the option to have all the ingresses use a cluster-wide ALB if we need to do that in the future.