### PR TITLE
fix: default to having ssl redirection on all ingresses

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -108,7 +108,7 @@ k + kubecfg {
     serviceName=name,
     servicePort='http',
     createTls=false,
-    createSSLRedirect=false,
+    createSSLRedirect=true,
     clusterALB=false,
     cluster_info=null,
   ): self.Ingress(name, namespace, app=app) {

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -108,7 +108,6 @@ k + kubecfg {
     serviceName=name,
     servicePort='http',
     createTls=false,
-    createSSLRedirect=true,
     clusterALB=false,
     cluster_info=null,
   ): self.Ingress(name, namespace, app=app) {
@@ -118,7 +117,7 @@ k + kubecfg {
     local rule = {
       host: this.host,
       http: {
-        paths: ( if createSSLRedirect != false then [ 
+        paths: [ 
           {
             path: '/*',
             backend: {
@@ -126,7 +125,6 @@ k + kubecfg {
               servicePort: 'use-annotation',
             },
           },
-        ] else [] ) + [
           {
             backend: {
               serviceName: serviceName,
@@ -146,11 +144,6 @@ k + kubecfg {
       'acm-manager.io/enable': 'true',
     },
 
-    local sslRedirectAnnotations = {
-      'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
-      'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-      'alb.ingress.kubernetes.io/group.order': '1', // Explicit order can't be 0
-    },
 
     metadata+: {
       annotations+: {
@@ -158,12 +151,13 @@ k + kubecfg {
         'kubernetes.io/ingress.class': 'alb',
         'alb.ingress.kubernetes.io/group.name': if clusterALB != false then cluster.global_name else this.host, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
         'alb.ingress.kubernetes.io/tags': 'outreach:environment=%s,kubernetesCluster=%s,outreach:application=%s,namespace=%s' % [cluster.environment, cluster.fqdn, name, namespace], 
-        'alb.ingress.kubernetes.io/listen-ports': '[{"HTTPS":443}]',
+        'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
+        'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/scheme': 'internet-facing',
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s' % [cluster.region, if clusterALB != false then cluster.global_name else this.host], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
-      } + (if createTls != false then tlsAnnotations else {}) + (if createSSLRedirect != false then sslRedirectAnnotations else {})
+      } + (if createTls != false then tlsAnnotations else {})
     },
     spec+: {
       rules: [


### PR DESCRIPTION
Having duplicate SSL redirection rules on ingresses does not seem to have a negative impact and serves to preserve the redirection correctly.