### PR TITLE
Set terminationMessagePolicy=FallbackToLogsOnError

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -264,6 +264,13 @@
     stdin: false,
     tty: false,
     assert !self.tty || self.stdin : 'tty=true requires stdin=true',
+    
+    // This will capture the final logs before your container died and 
+    // record them as the reason for termination (visible in kubectl describe pod).
+    // This is a saner default than the normal one, 
+    // which requires your application to write to /dev/termination-log before exiting.
+    // https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/
+    terminationMessagePolicy: 'FallbackToLogsOnError'
   },
 
   Pod(name): $._Object('v1', 'Pod', name) {


### PR DESCRIPTION
Not urgent, just nice-to-have.  I'd appreciate your consideration of this patch @getoutreach/fnd-cors.  Thank you!

---

See https://github.com/kubernetes/kubernetes/issues/78570 for rationale.

tl;dr if your container crashes you can see the final logs emitted by your process in `kubectl describe pod`

[I searched through org code](https://cs.github.com/?q=org%3Agetoutreach+%22%2Fdev%2Ftermination-log%22&p=1&pt=39f00a08c2ce45d8addd4f45005995a5a78fc1fb28fe282801639be6d4072bca1da339e8ac83571ef41801e71afefa0958dac64716a9cb12c43ddcecb22a9bbc2a321e5fbca978e2e1bf24f1ed6646def08c756f73145cbdfc7740e2&scope=&scopeName=All+repos) for writes to "/dev/termination-log" to see if we have any libraries that handle this for us via the default mechanism, but didn't see any.

