### PR TITLE
fix: remove argocd selfheal

### DIFF
--- a/kubernetes/argo.libsonnet
+++ b/kubernetes/argo.libsonnet
@@ -50,7 +50,6 @@ local argocdNamespace = 'argocd';
       syncPolicy: {
         automated: {
           prune: true,
-          selfHeal: false,
         },
         syncOptions: ['ApplyOutOfSyncOnly=false', 'PruneLast=true'],
       },


### PR DESCRIPTION
This issue happens only with applications that created from *-channel apps that have selfheal=true

1. *-channel apps was synced from github and it was trying to add selfheal=false and revert also image tag (VERSION) to original value which is empty as defined in https://github.com/getoutreach/applications (expected behavior)
2. maestro-updater patched application version with the correct versions from Maestro thru Kubernates API
3. ArgoCD detected that changes from step2 and patched ArgoCD applications and wiped off selfheal=false (ref: https://github.com/argoproj/argo-cd/blob/c702693380558c9fa06ddf4dee60484ab65138fc/pkg/apis/application/v1alpha1/types.go#L775)
4. a loop occur started here, ArgoCD repeats from step 1 again.