### PR TITLE
fix(concourse/maestro): fetch remote references before checkout

### DIFF
--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -602,6 +602,7 @@
         set -euf -o pipefail
         maestro_version=$(cat ./%s/version)
         cd source
+        mkdir -p "$HOME/.ssh"
         ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
         git fetch origin
         git checkout $maestro_version

--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -602,6 +602,7 @@
         set -euf -o pipefail
         maestro_version=$(cat ./%s/version)
         cd source
+        git fetch origin
         git checkout $maestro_version
       ||| % [maestro_resource_name],
     ],

--- a/concourse/templates.libsonnet
+++ b/concourse/templates.libsonnet
@@ -602,6 +602,7 @@
         set -euf -o pipefail
         maestro_version=$(cat ./%s/version)
         cd source
+        ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
         git fetch origin
         git checkout $maestro_version
       ||| % [maestro_resource_name],


### PR DESCRIPTION
**What this PR does**: This PR _should_ fix issues like [this](https://concourse.outreach.cloud/teams/devs/pipelines/searchreindexservice/jobs/Deploy%20app1d/builds/58):

```bash
selected worker: worker-8
error: pathspec 'v1.105.0' did not match any file(s) known to git
```

Even though `source` is up-to-date, it still fails to find the tag. So, this fetches from the remote before doing the checkout operation to ensure references are _always_ up-to-date.