### PR TITLE
fix(concourse/source): fetch_tags true

### DIFF
--- a/concourse/resources.libsonnet
+++ b/concourse/resources.libsonnet
@@ -166,6 +166,7 @@
         uri: 'git@github.com:' + $.source_repo + '.git',
         branch: $.branch,
         private_key: $.github_key,
+        fetch_tags: true,
       },
       webhook_token: $.webhook_token,
     },


### PR DESCRIPTION
Follow up to https://github.com/getoutreach/jsonnet-libs/pull/192

**What this PR does**: This PR fixes issues like [this](https://concourse.outreach.cloud/teams/devs/pipelines/searchreindexservice/jobs/Deploy%20app1d/builds/58):

```bash
selected worker: worker-8
error: pathspec 'v1.105.0' did not match any file(s) known to git
```