### PR TITLE
fix: Updating a minor bug in jsonnet-libs

### DIFF
--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -4,12 +4,14 @@ local resources = import 'resources.libsonnet';
 {
   DatabaseCredential(name, app, namespace): k._Object('databases.outreach.io/v1', 'DatabaseCredential', name, app=app, namespace=namespace) {
     username:: error 'username is required',
+    vault:: null,
+    iamauth:: false,
     local this = self,
     spec: {
       username: this.username,
       grants: this.grants,
-      vault: if std.objectHas(this, 'vault') then this.vault else null,
-      iamauth: if std.objectHas(this, 'iamauth') then this.iamauth else false,
+      vault: this.vault,
+      iamauth: this.iamauth,
     },
   },
   Grant(privileges, pattern): {


### PR DESCRIPTION
std.objectHas doesn't actually validate if hidden fields are present or not. This fixes it so that we properly assign the jsonnet. 
```
mukund.kidambi@C02FN542MD6R database-credential-operator %  kubecfg --jpath ../jsonnet-libs  --jurl http://k8s-clusters.outreach.cloud/ show -V "cluster=staging.us-east-2" -V "namespace=staging1a" -V "version=v1.5.0" manifests/onlineschemachange.databasecredential.jsonnet
---
apiVersion: databases.outreach.io/v1
kind: DatabaseCredential
metadata:
  annotations: {}
  labels:
    app: flagship
    name: onlineschemachange2
  name: onlineschemachange2
  namespace: staging1a
spec:
  grants:
  - pattern: '*.*'
    privileges:
    - REPLICATION CLIENT
    - REPLICATION SLAVE
    - PROCESS
  - pattern: outreach_%
    privileges:
    - ALL
  iamauth: false
  username: onlineschemachange2
  vault:
    passwordKey: onlineschemachange_password
    prefix: infrastructure/data/databases/global/credentials2
    usernameKey: onlineschemachange_username
```
```
(base) mukund.kidambi@C02FN542MD6R database-credential-operator %  kubecfg --jpath ../jsonnet-libs  --jurl http://k8s-clusters.outreach.cloud/ show -V "cluster=staging.us-east-2" -V "namespace=staging1a" -V "version=v1.5.0" manifests/iam-users.databasecredential.jsonnet
---
apiVersion: databases.outreach.io/v1
kind: DatabaseCredential
metadata:
  annotations: {}
  labels:
    app: flagship
    name: sre_admin_role
  name: sre_admin_role
  namespace: staging1a
spec:
  grants:
  - pattern: outreach_%
    privileges:
    - ALL
  - pattern: mysql.*
    privileges:
    - SELECT
  - pattern: performance_schema.*
    privileges:
    - SELECT
  iamauth: true
  username: sre_admin_role
  vault: null

```
Some test renders