### PR TITLE
fix: update spec for auth field

### DIFF
--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -5,13 +5,13 @@ local resources = import 'resources.libsonnet';
   DatabaseCredential(name, app, namespace): k._Object('databases.outreach.io/v1', 'DatabaseCredential', name, app=app, namespace=namespace) {
     username:: error 'username is required',
     vault:: null,
-    iamauth:: false,
+    auth:: 'mysql',
     local this = self,
     spec: {
       username: this.username,
       grants: this.grants,
       vault: this.vault,
-      iamauth: this.iamauth,
+      auth: this.iamauth,
     },
   },
   Grant(privileges, pattern): {

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -11,7 +11,7 @@ local resources = import 'resources.libsonnet';
       username: this.username,
       grants: this.grants,
       vault: this.vault,
-      auth: this.iamauth,
+      auth: this.auth,
     },
   },
   Grant(privileges, pattern): {


### PR DESCRIPTION
Update name and type of `auth` spec, this will allow us to extend the authentication methods in the future. Also it makes more sense what this spec means. Default will be set to `mysql` for mysql native password.