### PR TITLE
feat: add argo rollouts and analysis template

### DIFF
--- a/kubernetes/argo.libsonnet
+++ b/kubernetes/argo.libsonnet
@@ -459,11 +459,14 @@ local argocdNamespace = 'argocd';
   },
 
   // AnalysisMetricJob is a AnalysisTemplate metric with job provider
-  AnalysisMetricJob(name): $.AnalysisMetric(name) {
+  AnalysisMetricJob(name): {
     local this = self,
     job:: error 'job required',
+    name: name,
     provider: {
-      job: this.job,
+      job: {
+        spec: this.job.spec,
+      },
     },
   },
 }


### PR DESCRIPTION
https://outreach-io.atlassian.net/browse/DT-2917

EXAMPLE

```
canary: rollouts.CanaryDeployment(app.name, app.version, app.namespace) {
    deploymentRef:: $.deployment,
    previewService:: $.alb_service_preview,
    stableService:: $.alb_service,
    ingress:: $.ingress,
    servicePort:: 8080,
    steps:: [
      { setWeight: 10 },
      { pause: { duration: '5m' } },
      { setWeight: 30 },
      { pause: { duration: '5m' } },
      { setWeight: 50 },
      { pause: { duration: '5m' } },
      { setWeight: 70 },
      { pause: { duration: '5m' } },
      { setWeight: 100 },
    ],
    backgroundAnalysis:: {
      templates: [
        rollouts.AnalysisTemplateRef($.analysisMetric),
        rollouts.AnalysisTemplateRef($.analysisWeb),
      ],
      startingStep: 2,
    },
    metadata+: {
      labels+: sharedLabels,
    },
    spec+: {
      replicas: if isDev then 1 else 2,
    },
  },
  analysisWeb: rollouts.AnalysisTemplate('web-test', app) {
    metrics:: [
      rollouts.AnalysisMetricWeb('test-api') {
        url:: 'http://%(name)s-alb-preview.%(namespace)s:8080/info' % app,
        jsonPath:: '{$.data}',
        successCondition: 'result.ok && result.successPercent >= 0.90',
        interval: '1m',
      },
    ],
  },
  analysisMetric: rollouts.AnalysisTemplate('metric-test', app) {
    metrics:: [
      rollouts.AnalysisMetricDatadog("error-rate") {
        query:: 'count:{{args.app}}.http_request_seconds{status:5xx,bento:{{args.bento}},image_tag:{{args.version}}}.rollup(60).as_count() / count:{{args.app}}.http_request_seconds{bento:{{args.bento}},image_tag:{{args.version}}}.rollup(60).as_count()',
        successCondition: 'default(result, 0) <= 0.10',
        interval: '1m',
      },
    ],
  },
```