### PR TITLE
fix(helpers): remove app1c from appBentos

### DIFF
--- a/concourse/helpers.libsonnet
+++ b/concourse/helpers.libsonnet
@@ -39,16 +39,7 @@
       environment: 'production',
       region: 'us-west-2',
       passed: null,
-      next: 'app1c'
-    },
-    {
-      name: 'app1c',
-      cluster: 'production.us-west-2',
-      channel: 'green',
-      environment: 'production',
-      region: 'us-west-2',
-      passed: 'app1a',
-      next: 'app1f'
+      next: 'app2a'
     },
     {
       name: 'app2a',


### PR DESCRIPTION
**What this PR does**: This PR removes `app1c` from the `appBentos` helper to ensure pipelines don't automatically get it (legacy pipelines that use this function, that is)