### PR TITLE
fix: version is a required argument, fix CRDv1

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -131,8 +131,7 @@
     }
   ),
 
-  // TODO: update CRD to use v1 api once all clusters are 1.16+
-  CRDv1(kind, group, version):: (
+  CRDv1(kind, group, apiVersion='apiextensions.k8s.io/v1beta', resourceVersion='v1'):: (
     local names = {
       kind: kind,
       listKind: (kind + 'List'),
@@ -140,11 +139,11 @@
       singular: std.asciiLower(kind),
       full:: self.plural + '.' + group,
     };
-    $._Object('apiextensions.k8s.io/v1', 'CustomResourceDefinition', names.full) {
+    $._Object(apiVersion, 'CustomResourceDefinition', names.full) {
       spec: {
         group: group,
         names: names,
-        versions: [version],
+        versions: [resourceVersion],
       },
     }
   ),

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -132,7 +132,7 @@
   ),
 
   // TODO: update CRD to use v1 api once all clusters are 1.16+
-  CRDv1(kind, group):: (
+  CRDv1(kind, group, version):: (
     local names = {
       kind: kind,
       listKind: (kind + 'List'),
@@ -144,7 +144,7 @@
       spec: {
         group: group,
         names: names,
-        versions: error 'versions required',
+        version: version,
       },
     }
   ),

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -144,7 +144,7 @@
       spec: {
         group: group,
         names: names,
-        version: version,
+        versions: [version],
       },
     }
   ),
@@ -703,7 +703,7 @@
 
   LimitRange(name, namespace): $._Object('v1', 'LimitRange', name, namespace=namespace),
 
-  PodDisruptionBudget(name, namespace, app=name): $._Object('policy/v1beta1', 'PodDisruptionBudget', name, namespace=namespace) {
+  PodDisruptionBudget(name, namespace, app=name): $._Object('policy/v1', 'PodDisruptionBudget', name, namespace=namespace) {
     spec: {
       maxUnavailable: '50%',
       selector: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -131,7 +131,7 @@
     }
   ),
 
-  CRDv1(kind, group, apiVersion='apiextensions.k8s.io/v1beta', resourceVersion='v1'):: (
+  CRDv1(kind, group, apiVersion='apiextensions.k8s.io/v1beta', resourceVersions=['v1']):: (
     local names = {
       kind: kind,
       listKind: (kind + 'List'),
@@ -143,7 +143,7 @@
       spec: {
         group: group,
         names: names,
-        versions: [resourceVersion],
+        versions: resourceVersions,
       },
     }
   ),

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -164,8 +164,7 @@
     items: std.filter($.isNotNull, $.objectValues(self.items_)),
   },
 
-  Namespace(name): $._Object('v1', 'Namespace', name) {
-  },
+  Namespace(name): $._Object('v1', 'Namespace', name),
 
   Endpoints(name): $._Object('v1', 'Endpoints', name) {
     Ip(addr):: { ip: addr },
@@ -703,7 +702,8 @@
 
   LimitRange(name, namespace): $._Object('v1', 'LimitRange', name, namespace=namespace),
 
-  PodDisruptionBudget(name, namespace, app=name): $._Object('policy/v1', 'PodDisruptionBudget', name, namespace=namespace) {
+  PodDisruptionBudget(name, namespace, app=name, version='policy/v1'): $._Object( version,
+  'PodDisruptionBudget', name, namespace=namespace) {
     spec: {
       maxUnavailable: '50%',
       selector: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -702,8 +702,7 @@
 
   LimitRange(name, namespace): $._Object('v1', 'LimitRange', name, namespace=namespace),
 
-  PodDisruptionBudget(name, namespace, app=name, version='policy/v1'): $._Object( version,
-  'PodDisruptionBudget', name, namespace=namespace) {
+  PodDisruptionBudget(name, namespace, app=name): $._Object('policy/v1beta1', 'PodDisruptionBudget', name, namespace=namespace) {
     spec: {
       maxUnavailable: '50%',
       selector: {


### PR DESCRIPTION
updates `ok.CRDv1()`, version is pretty essential, and required argument. 

Also updates the PodDisruptionBudget version