### PR TITLE
feat(COR-5931)-ALB-set-Deletion-protection-ON

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -153,7 +153,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s,deletion_protection.enabled=true' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})
@@ -234,7 +234,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s,deletion_protection.enabled=true' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})


### PR DESCRIPTION
As followup task after ICM -> set for ALB attribute `Deletion protection ON` for prevent accidental 
deletion of ALB

was tested on cortest3 -> 
- added extra annotation to ing https://argocd.cortest3.us-east-2.outreach.cloud/applications/argo-rollouts?node=networking.k8s.io%2FIngress%2Fargo-rollouts%2Fargo-rollouts%2F0&resource= 
- was automatically set new attr to ALB -> https://us-east-2.console.aws.amazon.com/ec2/home?region=us-east-2#LoadBalancer:loadBalancerArn=arn:aws:elasticloadbalancing:us-east-2:182192988802:loadbalancer/app/k8s-cortest3useast2-ed70cf1a26/a4c34506f04ac5b8;tab=listeners
- Manual deletion was prevented with error `Failed to delete load balancer: Load balancer 'arn:aws:elasticloadbalancing:us-east-2:182192988802:loadbalancer/app/k8s-cortest3useast2-ed70cf1a26/a4c34506f04ac5b8' cannot be deleted because deletion protection is enabled`