### PR TITLE
feat: add hpa v2 func

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -534,6 +534,21 @@
     },
   },
 
+  HorizontalPodAutoscalerV2(name, namespace, app=name): $._Object('autoscaling/v2', 'HorizontalPodAutoscaler', name, app=app, namespace=namespace) {
+    local hpa = self,
+
+    target:: error 'target required',
+
+    spec: {
+      scaleTargetRef: $.CrossVersionObjectReference(hpa.target),
+
+      minReplicas: hpa.target.spec.replicas,
+      maxReplicas: error 'maxReplicas required',
+
+      assert self.maxReplicas >= self.minReplicas,
+    },
+  },
+
   VerticalPodAutoscaler(name, namespace, app=name): $._Object('autoscaling.k8s.io/v1beta2', 'VerticalPodAutoscaler', name, app=app, namespace=namespace) {
     local vpa = self,
     target:: error 'target required',


### PR DESCRIPTION
[COR-5864]

Because we have everywhere EKS 1.23, we can use HPA v2.

[COR-5864]: https://outreach-io.atlassian.net/browse/COR-5864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ