### PR TITLE
fix(app): deprecate the 'ts' extVar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 * @getoutreach/fnd-cors
 
 /kubernetes                    @getoutreach/fnd-cors
+/kubernetes/app.libsonnet      @getoutreach/fnd-dt
 /kubernetes/argo.libsonnet     @getoutreach/fnd-dt @getoutreach/fnd-cors
 /kubernetes/database.libsonnet @getoutreach/fnd-qss
+
 /concourse                     @getoutreach/fnd-dt

--- a/kubernetes/app.libsonnet
+++ b/kubernetes/app.libsonnet
@@ -32,7 +32,8 @@ local stdfields = {
   version: std.extVar('version'),
 
   // ts is when this application is being deployed as a timestamp.
-  ts: std.extVar('ts'),
+  // DEPRECATED: Don't use the ts value.
+  ts: '1690825986',
 
   // clusterType is the cluster type of the bento this application is being deployed to (legacy, ngb and shared-service)
   clusterType: if std.objectHas(cluster, 'type') then cluster.type else 'legacy',


### PR DESCRIPTION
The 'ts' extVar doesn't have much value and requires invocation of things like `date`. It's non-standard at Outreach. I propose we deprecate it and eventually remove the field.

Using the static value '1690825986' as the output of `date +%s` (one of the ways of generating it) of the deprecation time.