### PR TITLE
fix: rename o2p port name to meet char limit

### DIFF
--- a/kubernetes/oauth2-proxy.libsonnet
+++ b/kubernetes/oauth2-proxy.libsonnet
@@ -62,7 +62,7 @@ local ok = import 'kubernetes/kube.libsonnet';
       { secretRef: { name: secret.metadata.name } },
     ],
     ports_:: {
-      'http-oauth2-proxy': { containerPort: 8080 },
+      'http-o2p': { containerPort: 8080 },
     },
     resources: {
       limits: self.requests {


### PR DESCRIPTION
This PR is in response to an issue that I discovered when attempting to deploy `getoutreach/shedinja` on my local devenv. The error message was:

```
Error updating deployments shedinja--bento1a.shedinja: Deployment.apps "shedinja" is invalid: spec.template.spec.containers[2].ports[0].name: 
Invalid value: "http-oauth2-proxy": must be no more than 15 characters  app.name=shedinja app.type=bootstrap
ERRO[0021] failed to run: failed to deploy app: .: failed to deploy changes: exit status 1 
```

This PR fixes the issue by renaming `http-oauth2-proxy` to just `http-o2p` to fall under the 15 character limit