### PR TITLE
fix(oauth2-proxy): typo in listen_port

### DIFF
--- a/kubernetes/oauth2-proxy.libsonnet
+++ b/kubernetes/oauth2-proxy.libsonnet
@@ -62,7 +62,7 @@ local ok = import 'kubernetes/kube.libsonnet';
       { secretRef: { name: secret.metadata.name } },
     ],
     ports_:: {
-      'http-o2p': { containerPort: this.listenPort },
+      'http-o2p': { containerPort: this.listen_port },
     },
     resources: {
       limits: self.requests {


### PR DESCRIPTION
Accidentally put `listenPort` instead of `listen_port`... we need CI for
this repo. Sigh.
