### PR TITLE
feat: TLS1.3 for staging2b

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -234,7 +234,6 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -153,6 +153,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})
@@ -184,7 +185,14 @@ k + kubecfg {
     idleTimeoutSeconds="60"
   ): self.IngressV1(name, namespace, app=app) {
     local this = self,
-    local cluster = if cluster_info == null then import 'cluster.libsonnet' else cluster_info,
+    local cluster = {
+      name: std.extVar("cluster_name"),
+      region: std.extVar("cluster_region"),
+      dns_zone: std.extVar("cluster_dns_zone"),
+      environment: std.extVar("cluster_environment"),
+      cloud_provider:std.extVar("cluster_cloud_provider"),
+      fqdn:std.extVar("cluster_cloud_provider"),
+    };
     local scheme = if internal then 'internal' else 'internet-facing',
     local groupName = if groupBy != null then groupBy else if clusterALB != false && internal == false then cluster.global_name else if internal != false && clusterALB != false then cluster.global_name + '-internal' else this.host,
     host:: '%s.%s.%s' % [subdomain, cluster.global_name, ingressDomain],
@@ -228,10 +236,12 @@ k + kubecfg {
         'kubernetes.io/ingress.class': 'alb',
         'alb.ingress.kubernetes.io/ssl-redirect': '443',
         'alb.ingress.kubernetes.io/group.name': groupName, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
+        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -153,7 +153,6 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {})

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -3,7 +3,6 @@ local kubecfg = import 'kubecfg.libsonnet';
 
 local tls13 = [
   'staging1a.us-east-2.aws.outreach.cloud',
-  'app1d.us-west-2.aws.outreach.cloud',
 ];
 
 k + kubecfg {

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -239,7 +239,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-        'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
+        [if cluster.environment == 'staging' then 'alb.ingress.kubernetes.io/ssl-policy']: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -239,7 +239,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-        [if cluster.environment == 'staging' then 'alb.ingress.kubernetes.io/ssl-policy']: 'ELBSecurityPolicy-TLS13-1-2-2021-06' else 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
+        'alb.ingress.kubernetes.io/ssl-policy': if cluster.environment == 'staging' then 'ELBSecurityPolicy-TLS13-1-2-2021-06' else 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -2,7 +2,7 @@ local k = import 'kube.libsonnet';
 local kubecfg = import 'kubecfg.libsonnet';
 
 local tls13 = [
-  'staging1a.us-east-2.aws.outreach.cloud',
+  'staging2b.us-east-2.aws.outreach.cloud',
 ];
 
 k + kubecfg {

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -236,7 +236,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-        'alb.ingress.kubernetes.io/ssl-policy': if std.member(tls13, cluster.global_name) then 'ELBSecurityPolicy-TLS13-1-2-2021-06' else 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
+        'alb.ingress.kubernetes.io/ssl-policy': if std.member(tls13, cluster.fqdn) then 'ELBSecurityPolicy-TLS13-1-2-2021-06' else 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -228,7 +228,6 @@ k + kubecfg {
         'kubernetes.io/ingress.class': 'alb',
         'alb.ingress.kubernetes.io/ssl-redirect': '443',
         'alb.ingress.kubernetes.io/group.name': groupName, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
-        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -192,7 +192,7 @@ k + kubecfg {
       environment: std.extVar("cluster_environment"),
       cloud_provider:std.extVar("cluster_cloud_provider"),
       fqdn:std.extVar("cluster_cloud_provider"),
-    };
+    },
     local scheme = if internal then 'internal' else 'internet-facing',
     local groupName = if groupBy != null then groupBy else if clusterALB != false && internal == false then cluster.global_name else if internal != false && clusterALB != false then cluster.global_name + '-internal' else this.host,
     host:: '%s.%s.%s' % [subdomain, cluster.global_name, ingressDomain],

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -239,7 +239,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
         'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
-        [if cluster.environment == 'staging' then 'alb.ingress.kubernetes.io/ssl-policy']: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
+        [if cluster.environment == 'staging' then 'alb.ingress.kubernetes.io/ssl-policy']: 'ELBSecurityPolicy-TLS13-1-2-2021-06' else 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
         'alb.ingress.kubernetes.io/success-codes': '200-399',


### PR DESCRIPTION
Ticket: https://outreach-io.atlassian.net/browse/COR-6219
Change ALB policy in staging1a to TLS1.3. This is required by google as we have weak cihpers on our ALBs.
More bentos will follow up after testing this.

I used `cluster.fqdn` in condition for cluster name because I can see this is used in tags: https://github.com/getoutreach/jsonnet-libs/pull/252/files#diff-eb2627e12e96c449f5fae4526428b864114ef1bffbe7de58918adeca8d68d0b3R236

The value that this get interpolated into can be seen in the screenshot
![image](https://github.com/getoutreach/jsonnet-libs/assets/89030648/a44a1a24-9583-443c-ac22-90adc3676e32)
