### PR TITLE
feat: add DatadogMetric resource support

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -859,4 +859,13 @@
 
   // GoSecretData adds a helper for creating the go-outreach/gobox secretData struct
   GoSecretData(path): { Path: path },
+
+  DatadogMetric(name, namespace, app=name): $._Object('datadoghq.com/v1alpha1', 'DatadogMetric', name, namespace=namespace, app=app) {
+    local metric = self,
+
+    query_:: error 'query is required',
+    spec: {
+      query: metric.query_,
+    },
+  },
 }


### PR DESCRIPTION
To be used in [kube_bento](https://github.com/getoutreach/kube_bento/pull/1798) for configuring HPA resources