### PR TITLE
fix: failure-domain.beta.kubernetes.io/zone is deprecated

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -488,7 +488,7 @@
                   podAffinityTerm(k)
                   for k in [
                     'kubernetes.io/hostname',
-                    'failure-domain.beta.kubernetes.io/zone',
+                    'topology.kubernetes.io/zone',
                   ]
                 ],
               },
@@ -599,7 +599,7 @@
                         },
                       ],
                     },
-                    topologyKey: 'failure-domain.beta.kubernetes.io/zone',
+                    topologyKey: 'topology.kubernetes.io/zone',
                   },
                   weight: 100,
                 }],


### PR DESCRIPTION
failure-domain.beta.kubernetes.io/zone is a deprecated label as of K8 1.17, see https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesiozone

We should switch to use `topology.kubernetes.io/zone` instead.