### PR TITLE
feat: set target-type for ALBs to ip

### DIFF
--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -236,7 +236,7 @@ k + kubecfg {
         'alb.ingress.kubernetes.io/scheme': scheme,
         'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds],
         'alb.ingress.kubernetes.io/success-codes': '200-399',
-        'alb.ingress.kubernetes.io/target-type': 'ip',
+        [if cluster.environment == 'staging' then 'alb.ingress.kubernetes.io/target-type']: 'ip',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
       } + (if createTls != false then tlsAnnotations else {}),
     },

--- a/kubernetes/outreach.libsonnet
+++ b/kubernetes/outreach.libsonnet
@@ -55,17 +55,17 @@ k + kubecfg {
   },
 
   ContourHttpProxy(
-    name, 
+    name,
     namespace
-  ): self._Object('projectcontour.io/v1','HTTPProxy', name, namespace=namespace) {
-  serviceName_:: error 'serviceName_ is required to map httpProxy to a service',
-  fqdn_:: error 'fqdn_ is required',
-  tlsPassthrough_:: error 'tlsPassthrough_ is required. Either set true or false.',
-  tcpProxyPort_:: error 'tcpProxyPort_ is required',
-  routePort_:: error 'routePort_ is required',
-  routePrefix_:: error 'routePrefix_ is required',
+  ): self._Object('projectcontour.io/v1', 'HTTPProxy', name, namespace=namespace) {
+    serviceName_:: error 'serviceName_ is required to map httpProxy to a service',
+    fqdn_:: error 'fqdn_ is required',
+    tlsPassthrough_:: error 'tlsPassthrough_ is required. Either set true or false.',
+    tcpProxyPort_:: error 'tcpProxyPort_ is required',
+    routePort_:: error 'routePort_ is required',
+    routePrefix_:: error 'routePrefix_ is required',
 
-  local this = self,
+    local this = self,
     spec: {
       virtualhost: {
         fqdn: this.fqdn_,
@@ -99,7 +99,7 @@ k + kubecfg {
     },
   },
 
-  ALBIngress(    
+  ALBIngress(
     name,
     namespace,
     app=name,
@@ -112,7 +112,7 @@ k + kubecfg {
     clusterALB=false,
     groupBy=null,
     cluster_info=null,
-    idleTimeoutSeconds="60"
+    idleTimeoutSeconds='60'
   ): self.Ingress(name, namespace, app=app) {
     local this = self,
     local cluster = if cluster_info == null then import 'cluster.libsonnet' else cluster_info,
@@ -122,7 +122,7 @@ k + kubecfg {
     local rule = {
       host: this.host,
       http: {
-        paths: [ 
+        paths: [
           {
             backend: {
               serviceName: serviceName,
@@ -144,29 +144,29 @@ k + kubecfg {
 
     metadata+: {
       annotations+: {
-        # ALB ANNOTATIONS
+        // ALB ANNOTATIONS
         'kubernetes.io/ingress.class': 'alb',
         'alb.ingress.kubernetes.io/ssl-redirect': '443',
-        'alb.ingress.kubernetes.io/group.name': groupName, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
-        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
+        'alb.ingress.kubernetes.io/group.name': groupName,  // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
+        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn],
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
-        'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
+        'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}',  // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds],
         'alb.ingress.kubernetes.io/success-codes': '200-399',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
-      } + (if createTls != false then tlsAnnotations else {})
+      } + (if createTls != false then tlsAnnotations else {}),
     },
     spec+: {
       rules: [
-        rule
+        rule,
       ],
       [if createTls != false then 'tls']: [tls],
     },
   },
 
-  ALBIngressV1(    
+  ALBIngressV1(
     name,
     namespace,
     app=name,
@@ -182,7 +182,7 @@ k + kubecfg {
     clusterALB=false,
     groupBy=null,
     cluster_info=null,
-    idleTimeoutSeconds="60"
+    idleTimeoutSeconds='60'
   ): self.IngressV1(name, namespace, app=app) {
     local this = self,
     local cluster = if cluster_info == null then import 'cluster.libsonnet' else cluster_info,
@@ -192,7 +192,7 @@ k + kubecfg {
     local rule = {
       host: this.host,
       http: {
-        paths: [ 
+        paths: [
           {
             path: path,
             pathType: pathType,
@@ -200,13 +200,13 @@ k + kubecfg {
               service: {
                 name: serviceName,
                 port: if servicePortNumber != 0 then
-                {
-                  number: servicePortNumber
-                }
+                  {
+                    number: servicePortNumber,
+                  }
                 else
-                {
-                  name: if std.isString(servicePort) then servicePort else error "servicePort must be a string, to use an int use servicePortNumber instead"
-                },
+                  {
+                    name: if std.isString(servicePort) then servicePort else error 'servicePort must be a string, to use an int use servicePortNumber instead',
+                  },
               },
             },
           },
@@ -225,23 +225,24 @@ k + kubecfg {
 
     metadata+: {
       annotations+: {
-        # ALB ANNOTATIONS
+        // ALB ANNOTATIONS
         'kubernetes.io/ingress.class': 'alb',
         'alb.ingress.kubernetes.io/ssl-redirect': '443',
-        'alb.ingress.kubernetes.io/group.name': groupName, // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
-        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn], 
+        'alb.ingress.kubernetes.io/group.name': groupName,  // IngressGroup feature enables you to group multiple Ingress resources together and use a single ALB
+        'alb.ingress.kubernetes.io/tags': 'cost=ingress_alb,outreach:environment=%s,kubernetesCluster=%s' % [cluster.environment, cluster.fqdn],
         'alb.ingress.kubernetes.io/listen-ports': '[{"HTTP":80},{"HTTPS":443}]',
-        'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}', // Redirect http to https
+        'alb.ingress.kubernetes.io/actions.ssl-redirect': '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}',  // Redirect http to https
         'alb.ingress.kubernetes.io/ssl-policy': 'ELBSecurityPolicy-TLS13-1-2-Res-2021-06',
         'alb.ingress.kubernetes.io/scheme': scheme,
-        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds], 
+        'alb.ingress.kubernetes.io/load-balancer-attributes': 'routing.http.drop_invalid_header_fields.enabled=true,access_logs.s3.enabled=true,access_logs.s3.bucket=outreach-aws-lb-controller-logs-%s,access_logs.s3.prefix=%s,idle_timeout.timeout_seconds=%s' % [cluster.region, groupName, idleTimeoutSeconds],
         'alb.ingress.kubernetes.io/success-codes': '200-399',
+        'alb.ingress.kubernetes.io/target-type': 'ip',
         'external-dns.alpha.kubernetes.io/hostname': this.host,
-      } + (if createTls != false then tlsAnnotations else {})
+      } + (if createTls != false then tlsAnnotations else {}),
     },
     spec+: {
       rules: [
-        rule
+        rule,
       ],
       [if createTls != false then 'tls']: [tls],
     },


### PR DESCRIPTION
On the tin.

Adds the following annotation:
```
        'alb.ingress.kubernetes.io/target-type': 'ip',
```

Any other changes are from `jsonnetfmt` running.