### PR TITLE
Topology spread constraints

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -52,6 +52,10 @@
 // reference them.  In addition, jsonnet validation is more useful
 // (client-side, and gives better line information).
 
+// These are passed in as part of the pipeline
+local cluster = {
+  name: std.extVar("cluster_name"),
+};
 {
   // Returns array of values from given object.  Does not include hidden fields.
   objectValues(o):: [o[field] for field in std.objectFields(o)],
@@ -475,7 +479,7 @@
           },
         },
         template: {
-          spec: if std.member(topologySpreadConstraintsCluster, cluster.fqdn) then $.PodSpec {
+          spec: if std.member(topologySpreadConstraintsCluster, cluster.name) then $.PodSpec {
             // Set anti-affinity to help AZ distributiuon
             topologySpreadConstraints: [
               {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -53,9 +53,7 @@
 // (client-side, and gives better line information).
 
 // These are passed in as part of the pipeline
-local cluster = {
-  name: std.extVar("cluster_name"),
-};
+local bento = std.extVar('bento');
 {
   // Returns array of values from given object.  Does not include hidden fields.
   objectValues(o):: [o[field] for field in std.objectFields(o)],
@@ -464,7 +462,7 @@ local cluster = {
       metadata+: { labels+: { version: version } },
     },
   local topologySpreadConstraintsCluster = [
-    'staging1a.us-east-2.aws.outreach.cloud',
+    'staging1a',
   ],
 
   Deployment(name, namespace, app=name):
@@ -479,7 +477,7 @@ local cluster = {
           },
         },
         template: {
-          spec: if std.member(topologySpreadConstraintsCluster, cluster.name) then $.PodSpec {
+          spec: if std.member(topologySpreadConstraintsCluster, bento) then $.PodSpec {
             // Set anti-affinity to help AZ distributiuon
             topologySpreadConstraints: [
               {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -501,13 +501,13 @@ local bento = std.extVar('bento');
                 },
               },
             ],
+          },
             metadata: {
               labels: deployment.metadata.labels,
               annotations: {
                 'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
               },
             },
-          }
           else $.PodSpec {
             affinity: {
               podAntiAffinity: {
@@ -529,13 +529,13 @@ local bento = std.extVar('bento');
                 ],
               },
             },
+          },
             metadata: {
               labels: deployment.metadata.labels,
               annotations: {
                 'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
               },
             },
-          },
         },
         strategy: {
           type: 'RollingUpdate',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -501,13 +501,7 @@ local bento = std.extVar('bento');
                 },
               },
             ],
-          },
-            metadata: {
-              labels: deployment.metadata.labels,
-              annotations: {
-                'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
-              },
-            },
+          }
           else $.PodSpec {
             affinity: {
               podAntiAffinity: {
@@ -530,12 +524,12 @@ local bento = std.extVar('bento');
               },
             },
           },
-            metadata: {
-              labels: deployment.metadata.labels,
-              annotations: {
-                'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
-              },
+          metadata: {
+            labels: deployment.metadata.labels,
+            annotations: {
+              'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
             },
+          },
         },
         strategy: {
           type: 'RollingUpdate',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -473,26 +473,28 @@
         template: {
           spec: $.PodSpec {
             // Set anti-affinity to help AZ distributiuon
-            affinity: {
-              podAntiAffinity: {
-                local podAffinityTerm(topologyKey, weight=100) = {
-                  podAffinityTerm: {
-                    labelSelector: {
-                      matchExpressions: [{ key: 'name', operator: 'In', values: [name] }],
-                    },
-                    topologyKey: topologyKey,
+            topologySpreadConstraints: [
+              {
+                maxSkew: 1,
+                topologyKey: 'topology.kubernetes.io/zone',
+                whenUnsatisfiable: 'DoNotSchedule',
+                labelSelector: {
+                  matchLabels: {
+                    app: app,
                   },
-                  weight: weight,
                 },
-                preferredDuringSchedulingIgnoredDuringExecution: [
-                  podAffinityTerm(k)
-                  for k in [
-                    'kubernetes.io/hostname',
-                    'failure-domain.beta.kubernetes.io/zone',
-                  ]
-                ],
               },
-            },
+              {
+                maxSkew: 1,
+                topologyKey: 'kubernetes.io/hostname',
+                whenUnsatisfiable: 'ScheduleAnyway',
+                labelSelector: {
+                  matchLabels: {
+                    app: app,
+                  },
+                },
+              },
+            ],
           },
           metadata: {
             labels: deployment.metadata.labels,


### PR DESCRIPTION
_Reopening this PR as apps without `bento` should be mostly fixed._
This PR adds `topologySpreadConstraints` and removes `affinity` which should do the same thing (but didn't because it's just not flexible enough).
This PR does not add `minDomains` because it's still in beta and should graduate to stable in 1.27 and we are not there yet.

**Condition**
There is if/else conditional to apply this only on staging1a. The if/else statement is written so previous behavior with affinities is in `else` clause. In case the `bento` variable interpolates in something wrong, it will always fallback to current behavior.
`bento` is part of all argoCD application (unlike some thing we have in EKS addon like `cluster_name` etc.). You should be able to open any app here and there should be `BENTO` in parametets: https://argocd.app4a.eu-west-1.outreach.cloud/applications/argocd/syncinstanceconfig?resource=&node=argoproj.io%2FApplication%2Fargocd%2Fsyncinstanceconfig%2F0&tab=manifest

The labels to calculate topology are:

- required: `topology.kubernetes.io/zone`
- preferred: `kubernetes.io/hostname`

**Labels on current host**
```
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=m6idn.16xlarge
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=us-west-2
                    failure-domain.beta.kubernetes.io/zone=us-west-2a
                    k8s.io/cloud-provider-aws=7770fcadc07bd3c81829fbda4156314f
                    karpenter.k8s.aws/instance-category=m
                    karpenter.k8s.aws/instance-cpu=64
                    karpenter.k8s.aws/instance-encryption-in-transit-supported=true
                    karpenter.k8s.aws/instance-family=m6idn
                    karpenter.k8s.aws/instance-generation=6
                    karpenter.k8s.aws/instance-hypervisor=nitro
                    karpenter.k8s.aws/instance-local-nvme=3800
                    karpenter.k8s.aws/instance-memory=262144
                    karpenter.k8s.aws/instance-network-bandwidth=100000
                    karpenter.k8s.aws/instance-pods=737
                    karpenter.k8s.aws/instance-size=16xlarge
                    karpenter.sh/capacity-type=spot
                    karpenter.sh/initialized=true
                    karpenter.sh/provisioner-name=spot-nodes
                    karpenter.sh/registered=true
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=ip-10-64-26-168.us-west-2.compute.internal
                    kubernetes.io/os=linux
                    node.kubernetes.io/instance-type=m6idn.16xlarge
                    outreach.io/nodepool=spot
                    reporting_team=fnd-cor
                    spot=true
                    topology.ebs.csi.aws.com/zone=us-west-2a
                    topology.kubernetes.io/region=us-west-2
                    topology.kubernetes.io/zone=us-west-2a
```

**How to test this**
Change `bento` to `staging1a` and then something else (this is for aws-load-balancer-controller.jsonnet in eks-cluster-addons):
```
kubecfg show --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/topology-spread-constraints --jurl http://k8s-clusters.outreach.cloud/ -V "cluster_name=staging1a" -V "cluster_region=us=west-2" -V "bento=staging1a" addons/aws-load-balancer-controller/aws-load-balancer-controller.jsonnet
```