### PR TITLE
Revert "Topology spread constraints"

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -52,8 +52,6 @@
 // reference them.  In addition, jsonnet validation is more useful
 // (client-side, and gives better line information).
 
-// These are passed in as part of the pipeline
-local environment = std.extVar('environment');
 {
   // Returns array of values from given object.  Does not include hidden fields.
   objectValues(o):: [o[field] for field in std.objectFields(o)],
@@ -473,32 +471,8 @@ local environment = std.extVar('environment');
           },
         },
         template: {
-          spec: if environment == 'staging' then $.PodSpec {
+          spec: $.PodSpec {
             // Set anti-affinity to help AZ distributiuon
-            topologySpreadConstraints: [
-              {
-                maxSkew: 1,
-                topologyKey: 'topology.kubernetes.io/zone',
-                whenUnsatisfiable: 'DoNotSchedule',
-                labelSelector: {
-                  matchLabels: {
-                    name: name,
-                  },
-                },
-              },
-              {
-                maxSkew: 1,
-                topologyKey: 'kubernetes.io/hostname',
-                whenUnsatisfiable: 'ScheduleAnyway',
-                labelSelector: {
-                  matchLabels: {
-                    name: name,
-                  },
-                },
-              },
-            ],
-          }
-          else $.PodSpec {
             affinity: {
               podAntiAffinity: {
                 local podAffinityTerm(topologyKey, weight=100) = {
@@ -527,6 +501,7 @@ local environment = std.extVar('environment');
             },
           },
         },
+
         strategy: {
           type: 'RollingUpdate',
 
@@ -551,6 +526,7 @@ local environment = std.extVar('environment');
         },
       },
     },
+
   CrossVersionObjectReference(target): {
     apiVersion: target.apiVersion,
     kind: target.kind,


### PR DESCRIPTION
Reverts getoutreach/jsonnet-libs#271

All apps except `flagship` were ok. However flagship remained in `Unknown` state where we couldn't keep it. We have to look into the error but revert this in the meantime
```
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): plugin sidecar failed. error generating manifests in cmp: rpc error: code = Unknown desc = error generating manifests: `/bin/sh -c "argocd-maestro-plugin get-variable --channel \"$ARGOCD_MAESTRO_PLUGIN_CHANNEL\" --bento \"$ARGOCD_MAESTRO_PLUGIN_BENTO\" --application $ARGOCD_APP_NAME | xargs kubecfg --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/master --jpath /opt/jsonnet-libs show $(argocd-maestro-plugin get-manifestpath || echo \"invalid path\" && exit 1) -oyaml > /tmp/generated_$ARGOCD_APP_NAME.yaml"` failed exit status 123: error reading scheduler.jsonnet: RUNTIME ERROR: Attempt to use super when there is no super class. file:///tmp/_cmp_server/15fe12ec-6a11-4fb7-8907-96de581ac3a0/manifests/libs/server.libsonnet:63:29-34 object <anonymous> file:///tmp/_cmp_server/15fe12ec-6a11-4fb7-8907-96de581ac3a0/manifests/libs/server.libsonnet:(61:64)-(64:16) Field "preferredDuringSchedulingIgnoredDuringExecution" Field "podAntiAffinity" Field "affinity" Field "spec" Field "template" Field "spec" Array element 0 Field "items" During manifestation
```