### PR TITLE
feat: maxSkew increase for hostname

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -487,7 +487,7 @@ local environment = std.extVar('environment');
                 },
               },
               {
-                maxSkew: 1,
+                maxSkew: 2,
                 topologyKey: 'kubernetes.io/hostname',
                 whenUnsatisfiable: 'ScheduleAnyway',
                 labelSelector: {


### PR DESCRIPTION
`maxSkew` of `1` means there cannot be bigger difference between 2 nodes running the same deployment than 1. In other words one host cannot run 2 pods while other has 0.
Changing this to `2` does allow bigger difference.
Main reason for this change is that karpenter treats this as hard requirement even with `ScheduleAnyway` and will not drain nodes which would violate this.

We can later discuss if we want to have this still `1` in production or if `2` is enough for us even there but in staging we can go with 2 or even more because it allows karpenter to consolidate nodes better.