### PR TITLE
feat: topologySpreadConstraints on production

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -473,7 +473,7 @@ local environment = std.extVar('environment');
           },
         },
         template: {
-          spec: if environment == 'staging' then $.PodSpec {
+          spec: {
             // Set anti-affinity to help AZ distributiuon
             topologySpreadConstraints: [
               {
@@ -497,28 +497,6 @@ local environment = std.extVar('environment');
                 },
               },
             ],
-          }
-          else $.PodSpec {
-            affinity: {
-              podAntiAffinity: {
-                local podAffinityTerm(topologyKey, weight=100) = {
-                  podAffinityTerm: {
-                    labelSelector: {
-                      matchExpressions: [{ key: 'name', operator: 'In', values: [name] }],
-                    },
-                    topologyKey: topologyKey,
-                  },
-                  weight: weight,
-                },
-                preferredDuringSchedulingIgnoredDuringExecution: [
-                  podAffinityTerm(k)
-                  for k in [
-                    'kubernetes.io/hostname',
-                    'failure-domain.beta.kubernetes.io/zone',
-                  ]
-                ],
-              },
-            },
           },
           metadata: {
             labels: deployment.metadata.labels,


### PR DESCRIPTION
Moves what we had on staging to production. All deployments will go out of sync and we will not sync them all to prevent syncing unwanted to prod. We might do automated sync after some time to finish what was left.
I plan to merge this tomorrow morning 09:00 - 10:00 CEST (00:00 - 01:00 PST).

Verified `kubecfg` manifest from this branch on coredns.