### PR TITLE
feat: affinity for hostname

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -508,17 +508,26 @@ local environment = std.extVar('environment');
                   },
                 },
               },
-              {
-                maxSkew: 2,
-                topologyKey: 'kubernetes.io/hostname',
-                whenUnsatisfiable: 'ScheduleAnyway',
-                labelSelector: {
-                  matchLabels: {
-                    name: name,
-                  },
-                },
-              },
             ],
+            affinity: {
+              podAntiAffinity: {
+                local podAffinityTerm(topologyKey, weight=100) = {
+                  podAffinityTerm: {
+                    labelSelector: {
+                      matchExpressions: [{ key: 'name', operator: 'In', values: [name] }],
+                    },
+                    topologyKey: topologyKey,
+                  },
+                  weight: weight,
+                },
+                preferredDuringSchedulingIgnoredDuringExecution: [
+                  podAffinityTerm(k)
+                  for k in [
+                    'kubernetes.io/hostname',
+                  ]
+                ],
+              },
+            },
           },
           metadata: {
             labels: deployment.metadata.labels,


### PR DESCRIPTION
This removed `topologySpreadConstraints` for `kubernetes.io/hostname` and return affinity for the same label.
We are changing this part back because we saw many new and small nodes coming from this previous change. `topologySpreadConstraints` with `maxSkew` caused karpenter to prepare small nodes and k8s then spread all pods from single deployment across all of them.
In the end this would mean additional cost because we have a lot bigger overhead from daemonsets now. It is also causing problems for karpenter during scaleups as it gets ratelimited by AWS because it tries to create many small instances.
Our clusters started scaling up on big number of very small nodes to satisfy the `topologySpreadConstraints` constraint.
Cluster node count in past 48 hours
![image](https://github.com/getoutreach/jsonnet-libs/assets/89030648/0a383ed9-6980-4553-8f9d-dfc64d6f2f34)

Adds
![image](https://github.com/getoutreach/jsonnet-libs/assets/89030648/208ec56f-9791-41f5-b808-b80356634e4a)

Removes
![image](https://github.com/getoutreach/jsonnet-libs/assets/89030648/8c96ba8e-0ced-4f9c-af54-ddbac50f61b3)

