### PR TITLE
feat(database): add PostgresqlClusterServiceAssignment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+gcr_auth: &gcr_auth
+  auth:
+    username: _json_key
+    password: $GCLOUD_SERVICE_ACCOUNT
+
+jobs:
+  test:
+    docker:
+      - image: gcr.io/outreach-docker/bootstrap/ci-slim:stable
+        <<: *gcr_auth
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: make test
+    
+workflows:
+  build_and_test:
+    jobs:
+      - test:
+          context:
+            - docker-registry

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ https://github.com/getoutreach/concourse-example/blob/master/ci/pipeline.jsonnet
 git clone git@github.com:getoutreach/jsonnet-libs.git /tmp/jsonnet-libs
 jsonnet -J /tmp/jsonnet-libs -y pipeline.jsonnet
 ```
+
+### Testing
+jsonnet files created under the `./tests` directory can be used to test libsonnet functions. The files will be rendered to identically named `.snap` files in the same directory.
+Snapshots are regenerated each time the tests are run.
+```sh
+make test
+```

--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -19,6 +19,45 @@ local k = import 'kubernetes/kube.libsonnet';
     privileges: privileges,
     pattern: pattern,
   },
+  // PostgresqlClusterServiceAssignment is used to provision the resources for a service to be able to connect to a database cluster.
+  PostgresqlClusterServiceAssignment(
+    // name is the name of this k8s resource
+    name,
+    // app is the name of the application which needs to access the database cluster
+    app,
+    // namespace is the k8s namespace where this PostgresqlClusterServiceAssignment should be declared
+    namespace,
+  ): k._Object(
+    'databases.outreach.io/v1',
+    'PostgresqlClusterServiceAssignment',
+    name,
+    app=app,
+    namespace=namespace,
+  ) {
+    local this = self,
+    // bento is the bento which contains the database cluster and application
+    bento:: error 'bento is required',
+      // database_cluster_name is the k8s resource name of the PostgresqlDatabaseCluster
+    database_cluster_name:: error 'database_cluster_name is required',
+    // database_cluster_namespace is the k8s namespace where the PostgresqlDatabaseCluster is declared.
+    database_cluster_namespace:: error 'database_cluster_namespace is required',
+    // resource attribution tags (team, tier, personal_information)
+    // https://outreach-io.atlassian.net/wiki/spaces/COR/pages/2173993240/Resource+Tagging+Standards+COR
+    team:: error 'team is required',
+    tier:: error 'tier is required',
+    personal_information:: error 'personal_information is required',
+    spec: std.prune({
+      application_name: app,
+      postgresql_database_cluster: {
+        namespace: this.database_cluster_namespace,
+        resource_name: this.database_cluster_name,
+      },
+      bento: this.bento,
+      team: this.team,
+      tier: this.tier,
+      personal_information: this.personal_information,
+    }),
+  },
   PostgresqlDatabaseCluster(database_cluster_name, app, namespace, environment=''): k._Object('databases.outreach.io/v1', 'PostgresqlDatabaseCluster', name=database_cluster_name, app=app, namespace=namespace) {
     local this = self,
     // You can find instance class description here:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -27,6 +27,7 @@ for test in "$TEST_DIR"/*.jsonnet; do
 done
 
 if (( ${#failed_tests[@]} )); then
-    >&2 echo "snapshots did not match and were updated: ${failed_tests[*]}"
+    failed_tests_csv="$(IFS=,; echo "${failed_tests[*]}")"
+    >&2 echo "snapshots did not match and were updated: $failed_tests_csv"
     exit 1
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+TEST_DIR="$DIR/../tests"
+
+failed_tests=()
+for test in "$TEST_DIR"/*.jsonnet; do
+    filename=$(basename -- "$test")
+    filename="${filename%.*}"
+    snapshot="$(dirname "$test")/$filename.snap"
+    result=$(mktemp)
+    kubecfg \
+    --jurl http://k8s-clusters.outreach.cloud/ \
+    --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/master \
+    --jpath "$DIR/../" \
+    -V environment=development \
+    show "$test" > "$result"
+
+    
+    if ! diff "$snapshot" "$result" >/dev/null 2>&1; then
+        failed_tests+=("$filename")
+    fi
+
+    cat "$result" > "$snapshot"
+done
+
+if (( ${#failed_tests[@]} )); then
+    >&2 echo "snapshots did not match and were updated: ${failed_tests[*]}"
+    exit 1
+fi

--- a/tests/database.jsonnet
+++ b/tests/database.jsonnet
@@ -1,0 +1,16 @@
+local database = import 'kubernetes/database.libsonnet';
+
+{
+    assignment: database.PostgresqlClusterServiceAssignment(
+        "custom-resource-instance-name",
+        app="my-app",
+        namespace="my-app--bento1a"
+    ) {
+        bento:: "bento1a",
+        personal_information:: "yes",
+        database_cluster_namespace:: "shared-databases--bento1a",
+        database_cluster_name:: "my-shared-database",
+        team:: "fnd-qss",
+        tier:: "tier-2",
+    },
+}

--- a/tests/database.snap
+++ b/tests/database.snap
@@ -1,0 +1,19 @@
+---
+apiVersion: databases.outreach.io/v1
+kind: PostgresqlClusterServiceAssignment
+metadata:
+  annotations: {}
+  labels:
+    app: my-app
+    name: custom-resource-instance-name
+  name: custom-resource-instance-name
+  namespace: my-app--bento1a
+spec:
+  application_name: my-app
+  bento: bento1a
+  personal_information: "yes"
+  postgresql_database_cluster:
+    namespace: shared-databases--bento1a
+    resource_name: my-shared-database
+  team: fnd-qss
+  tier: tier-2


### PR DESCRIPTION
Add a libsonnet function for rendering PostgresqlClusterServiceAssignment resources. Add a way to define and run tests.

I can't test out the CI config until after this is merged. I'll fix any issues that may occur once this is in.

QSS-2346