### PR TITLE
feat(staging): no antiaffinity for hostname

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -495,6 +495,19 @@ local environment = std.extVar('environment');
                 ],
               },
             },
+          } else if environment == 'staging' then $.PodSpec {
+            topologySpreadConstraints: [
+              {
+                maxSkew: 1,
+                topologyKey: 'topology.kubernetes.io/zone',
+                whenUnsatisfiable: 'DoNotSchedule',
+                labelSelector: {
+                  matchLabels: {
+                    name: name,
+                  },
+                },
+              },
+            ],
           }
           else $.PodSpec {
             topologySpreadConstraints: [


### PR DESCRIPTION
We are still seeing high amount of tiny nodes. We will remove this in staging. The goal is to see bigger nodes. If we see this is causing too many pods of single deployment on one node, we will return to `topologySpreadConstraints` on `hostname` with higher `maxSkew` but removing this first and then potentially going back looks to be simpler approach then trying to tune `maxSkew` for the sweetspot.