### PR TITLE
fix: temp_builtin_users was never needed/used

### DIFF
--- a/kubernetes/database.libsonnet
+++ b/kubernetes/database.libsonnet
@@ -84,7 +84,7 @@ local k = import 'kubernetes/kube.libsonnet';
     tier:: error 'tier is required',
     personal_information:: '',
     full_name:: '',
-    temp_builtin_users:: false,
+    temp_builtin_users:: null,
     engine:: {
       version: error 'engine.version is required',
       parameter_group_family: error 'engine.parameter_group_family is required',


### PR DESCRIPTION
null for now, will eventually be removed

This change should be safe, any calls that provide the value will be respected, when to provided, temp_builtin_users will be pruned.