### PR TITLE
fix(oauth2-proxy): increase cpu limit

### DIFF
--- a/kubernetes/oauth2-proxy.libsonnet
+++ b/kubernetes/oauth2-proxy.libsonnet
@@ -67,11 +67,12 @@ local appImageRegistry = std.extVar('appImageRegistry');
       'http-o2p': { containerPort: this.listen_port },
     },
     resources: {
-      limits: self.requests {
+      limits: {
+        cpu: '300m',
         memory: '200Mi',
       },
       requests: {
-        cpu: '10m',
+        cpu: '100m',
         memory: '110Mi',
       },
     },


### PR DESCRIPTION
Increase the CPU limit from 10m to 300m to prevent CPU starvation.
I noticed that request latency to Dash increased with concurrency. I tested this with a bash script and reproduced the issue. I suspected some bottleneck in the oauth2-proxy since the traces indicated that downstream requests (maestro and promototron) were completing much faster. I tested this manually and saw great improvements in page load time and reduced network latency.

The following before/after shows a set of parallel requests before and after the change to increase the cpu limit.

Before (~1s):
<img width="1846" height="1005" alt="image" src="https://github.com/user-attachments/assets/d806878f-a78d-4fee-b9ba-0f5adebcaf00" />


After (~80ms):
<img width="1846" height="1005" alt="image" src="https://github.com/user-attachments/assets/1c964e3f-cf5b-4c0b-a0ac-948e1600b954" />
