### PR TITLE
fix: waypoint configmap name

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -921,7 +921,7 @@ local environment = std.extVar('environment');
       },
     },
 
-  WaypointProxyConfig(name='waypoint-config', namespace, team): self.ConfigMap('waypoint-config', namespace, team) {
+  WaypointProxyConfig(name='waypoint-config', namespace, team): self.ConfigMap(name, namespace, team) {
     metadata+: {
       labels+: {
         reporting_team: team,

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -915,7 +915,7 @@ local environment = std.extVar('environment');
           parametersRef: {
             group: '',
             kind: 'ConfigMap',
-            name: 'waypoint-config',
+            name: name,
           },
         },
       },


### PR DESCRIPTION
Before
```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  annotations: {}
  labels:
    istio.io/waypoint-for: all
    name: server-internal-waypoint
    reporting_team: fnd-pc
  name: server-internal-waypoint
  namespace: staging1a
spec:
  gatewayClassName: istio-waypoint
  infrastructure:
    parametersRef:
      group: ""
      kind: ConfigMap
      name: waypoint-config
  listeners:
  - name: mesh
    port: 15008
    protocol: HBONE
---
apiVersion: v1
data:
  deployment: |-
    "spec":
      "template":
        "spec":
          "nodeSelector":
            "outreach.io/nodepool": "ondemand"
          "priorityClassName": "system-cluster-critical"
          "tolerations":
          - "effect": "NoSchedule"
            "key": "dedicated"
            "operator": "Equal"
            "value": "ondemand"
kind: ConfigMap
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "-4"
  labels:
    app: fnd-pc
    name: waypoint-config
    reporting_team: fnd-pc
  name: waypoint-config
  namespace: staging1a
```



After
```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  annotations: {}
  labels:
    istio.io/waypoint-for: all
    name: server-internal-waypoint
    reporting_team: fnd-pc
  name: server-internal-waypoint
  namespace: staging1a
spec:
  gatewayClassName: istio-waypoint
  infrastructure:
    parametersRef:
      group: ""
      kind: ConfigMap
      name: server-internal-waypoint
  listeners:
  - name: mesh
    port: 15008
    protocol: HBONE
---
apiVersion: v1
data:
  deployment: |-
    "spec":
      "template":
        "spec":
          "nodeSelector":
            "outreach.io/nodepool": "ondemand"
          "priorityClassName": "system-cluster-critical"
          "tolerations":
          - "effect": "NoSchedule"
            "key": "dedicated"
            "operator": "Equal"
            "value": "ondemand"
kind: ConfigMap
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "-4"
  labels:
    app: fnd-pc
    name: server-internal-waypoint
    reporting_team: fnd-pc
  name: server-internal-waypoint
  namespace: staging1a
```