### PR TITLE
feat: waypoint pdb and hpa

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -945,7 +945,7 @@ local environment = std.extVar('environment');
               topologySpreadConstraints: [{
                 labelSelector: {
                   matchLabels: {
-                    'gateway.networking.k8s.io/gateway-name': 'scaleops-waypoint',
+                    'gateway.networking.k8s.io/gateway-name': name,
                   },
                 },
                 maxSkew: 1,
@@ -963,7 +963,7 @@ local environment = std.extVar('environment');
           scaleTargetRef: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',
-            name: 'scaleops-waypoint',
+            name: name,
           },
           metrics: [{
             type: 'Resource',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -970,7 +970,7 @@ local environment = std.extVar('environment');
     },
   },
 
-  WaypointProxyPdb(name='waypoint-hpa', namespace, team): $._Object('policy/v1', 'PodDisruptionBudget', name, namespace=namespace) {
+  WaypointProxyPdb(name='waypoint-pdb', namespace, team): $._Object('policy/v1', 'PodDisruptionBudget', name, namespace=namespace) {
     spec+: {
       minAvailable: 1,
       selector: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -928,7 +928,7 @@ local environment = std.extVar('environment');
       },
     },
     data+: {
-      deployment: std.manifestYamlDoc({
+      deployment+: std.manifestYamlDoc({
         spec: {
           template: {
             spec: {
@@ -956,7 +956,7 @@ local environment = std.extVar('environment');
           },
         },
       }),
-      horizontalPodAutoscaler: std.manifestYamlDoc({
+      horizontalPodAutoscaler+: std.manifestYamlDoc({
         spec: {
           minReplicas: 2,
           maxReplicas: 6,
@@ -977,7 +977,7 @@ local environment = std.extVar('environment');
           }],
         },
       }),
-      podDisruptionBudget: std.manifestYamlDoc({
+      podDisruptionBudget+: std.manifestYamlDoc({
         spec: {
           minAvailable: 1,
         },

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -948,6 +948,28 @@ local environment = std.extVar('environment');
       }),
     },
   },
+  WaypointProxyHpa(name='waypoint-hpa', namespace, team): $._Object('autoscaling/v2', 'HorizontalPodAutoscaler', name, namespace=namespace) {
+    spec+: {
+      scaleTargetRef: {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        name: self.WaypointProxy.name,
+      },
+      minReplicas: 1,
+      maxReplicas: 3,
+      metrics: [{
+        type: 'Resource',
+        resource: {
+          name: 'cpu',
+          target: {
+            type: 'Utilization',
+            averageUtilization: 60,
+          },
+        },
+      }],
+    },
+  },
+
   GatewayConfig(name='gateway', namespace): $._Object('gateway.networking.k8s.io/v1', 'Gateway', name, namespace=namespace) {
     metadata+: {
       labels+: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -953,7 +953,7 @@ local environment = std.extVar('environment');
       scaleTargetRef: {
         apiVersion: 'apps/v1',
         kind: 'Deployment',
-        name: self.WaypointProxy.name,
+        name: $.WaypointProxy.name,
       },
       minReplicas: 1,
       maxReplicas: 3,

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -970,6 +970,17 @@ local environment = std.extVar('environment');
     },
   },
 
+  WaypointProxyPdb(name='waypoint-hpa', namespace, team): $._Object('policy/v1', 'PodDisruptionBudget', name, namespace=namespace) {
+    spec+: {
+      minAvailable: 1,
+      selector: {
+        matchLabels: {
+          name: self.WaypointProxy.name,
+        },
+      },
+    },
+  },
+
   GatewayConfig(name='gateway', namespace): $._Object('gateway.networking.k8s.io/v1', 'Gateway', name, namespace=namespace) {
     metadata+: {
       labels+: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -953,7 +953,7 @@ local environment = std.extVar('environment');
       scaleTargetRef: {
         apiVersion: 'apps/v1',
         kind: 'Deployment',
-        name: $.WaypointProxy.name,
+        name: name,
       },
       minReplicas: 1,
       maxReplicas: 3,
@@ -975,7 +975,7 @@ local environment = std.extVar('environment');
       minAvailable: 1,
       selector: {
         matchLabels: {
-          name: self.WaypointProxy.name,
+          name: name,
         },
       },
     },


### PR DESCRIPTION
Add default sane configuration for all waypoints. This configuration assumes:

- at least 2 replicas (max 6 for now)
- PDB with maxUnavailable 1
- TSC with zone topology key
- always on `ondemand` nodes
- HPA with 80% CPU (we might need to tune this later)
- `system-cluster-critical` priority class

If waypoint doesn't do anything it will run as two replicas and scaleops should modify it to really low resources but we need to have them ready to handle more load. Staging1a list:
<img width="1885" height="568" alt="image" src="https://github.com/user-attachments/assets/7563add3-c9e3-46bd-ba99-49a70bd88502" />
