### PR TITLE
feat: waypoint default sizing

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -953,6 +953,17 @@ local environment = std.extVar('environment');
                 whenUnsatisfiable: 'DoNotSchedule',
               }],
             },
+            containers: [{
+              resources: {
+                requests: {
+                  cpu: '500m',
+                  memory: '200Mi',
+                },
+                limits: {
+                  memory: '150Mi',
+                },
+              },
+            }],
           },
         },
       }),

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -964,7 +964,7 @@ local environment = std.extVar('environment');
                     },
                   },
                 }],
-                memory: 200Mi
+            },
           },
         },
       }),

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -952,18 +952,19 @@ local environment = std.extVar('environment');
                 topologyKey: 'topology.kubernetes.io/zone',
                 whenUnsatisfiable: 'DoNotSchedule',
               }],
-            },
-            containers: [{
-              resources: {
-                requests: {
-                  cpu: '500m',
-                  memory: '200Mi',
-                },
-                limits: {
-                  memory: '150Mi',
-                },
-              },
-            }],
+                containers: [{
+                  name: 'istio-proxy',
+                  resources: {
+                    limits: {
+                      memory: '1Gi',
+                    },
+                    requests: {
+                      cpu: '500m',
+                      memory: '200Mi',
+                    },
+                  },
+                }],
+                memory: 200Mi
           },
         },
       }),


### PR DESCRIPTION
We don't want to have many small waypoints but rather bigger one that don't scale that often. Also looks like currently scaleops doesn't optimize waypoint (because they are owned by Gateway which is not supported) so we can't rely on scaleops bumping resources up.