### PR TITLE
Add sync-wave annotation to ServiceAccount

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -718,6 +718,11 @@ local environment = std.extVar('environment');
   },
 
   ServiceAccount(name, namespace, app=name): $._Object('v1', 'ServiceAccount', name, namespace=namespace, app=app) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-wave': '-5',
+      },
+    },
   },
 
   Role(name, app=name, namespace=null): $._Object('rbac.authorization.k8s.io/v1', 'Role', name, app=app, namespace=namespace) {


### PR DESCRIPTION
Introduce a sync-wave annotation to the ServiceAccount for better synchronization control in Argo CD.