### PR TITLE
Add default-rightsize-policy annotation for high availability

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -942,6 +942,11 @@ local environment = std.extVar('environment');
       deployment+: std.manifestYamlDoc({
         spec: {
           template: {
+            metadata: {
+              annotations: {
+                'scaleops.sh/default-rightsize-policy': 'high-availability',
+              },
+            },
             spec: {
               nodeSelector: {
                 'outreach.io/nodepool': 'ondemand',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -987,7 +987,7 @@ local environment = std.extVar('environment');
       horizontalPodAutoscaler+: std.manifestYamlDoc({
         spec: {
           minReplicas: 2,
-          maxReplicas: 6,
+          maxReplicas: 10,
           scaleTargetRef: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -987,7 +987,7 @@ local environment = std.extVar('environment');
       horizontalPodAutoscaler+: std.manifestYamlDoc({
         spec: {
           minReplicas: 2,
-          maxReplicas: 10,
+          maxReplicas: 6,
           scaleTargetRef: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',


### PR DESCRIPTION
Introduce the `scaleops.sh/default-rightsize-policy` annotation to enhance deployment configurations for high availability.