### PR TITLE
chore(COR-6543): remove k8s-clusters S3 bucket dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ https://github.com/getoutreach/concourse-example/blob/master/k8s/manifests/deplo
 
 ```Bash
 kubecfg \
---jurl http://k8s-clusters.outreach.cloud/ \
 --jurl https://jsonnet-libs.outreach.cloud/ \
 show deployment.jsonnet
 ```
@@ -31,7 +30,6 @@ To use jsonnet-libs from a particular branch of this repository, you can use the
 ```Bash
 export BRANCH=your-branch
 kubecfg \
---jurl http://k8s-clusters.outreach.cloud/ \
 --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/$BRANCH \
 show deployment.jsonnet
 ```

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,7 +12,6 @@ for test in "$TEST_DIR"/*.jsonnet; do
     snapshot="$(dirname "$test")/$filename.snap"
     result=$(mktemp)
     kubecfg \
-    --jurl http://k8s-clusters.outreach.cloud/ \
     --jurl https://raw.githubusercontent.com/getoutreach/jsonnet-libs/master \
     --jpath "$DIR/../" \
     -V environment=development \


### PR DESCRIPTION
## Reason

`scripts/test.sh` and the `README.md` examples passed `--jurl http://k8s-clusters.outreach.cloud/` to kubecfg. That bucket is a **High** pentest finding — world-readable / anonymously listable ([COR-6543](https://outreach-io.atlassian.net/browse/COR-6543), *AWS S3: Bucket world-readable (anonymous)*) — and is being decommissioned. All readers must stop depending on it so the bucket can be locked down and deleted.

## Fix

**Pattern: vestigial `--jurl`.** The snapshot tests (`tests/database.jsonnet`, `tests/kube.jsonnet`) don't use the `cluster.libsonnet` → `clusters.yaml[extVar('cluster')]` lookup (no `-V cluster` is passed), so the S3 jurl was never actually exercised. Removed it from `scripts/test.sh` and both `README.md` usage examples; kept the jsonnet-libs jurl.

Files changed: `scripts/test.sh`, `README.md`.

## Verification

- Ran `./scripts/test.sh` with the S3 jurl removed → **exit 0, no snapshot drift** (committed `.snap` fixtures unchanged).
- ArgoCD's production GitOps path does not use this bucket (per-instance `cluster-info` ConfigMap), so this change is dev/CI-tooling only and cannot affect deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COR-6543]: https://outreach-io.atlassian.net/browse/COR-6543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ