### PR TITLE
fix: harden ServiceMonitor (port detection, selector, interval)

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -782,6 +782,34 @@ local environment = std.extVar('environment');
     },
   },
 
+  // ServiceMonitor selects a Service and scrapes its metrics port. Pass the
+  // target Service via target_service:: -- the metrics port (named or targeting
+  // 'metrics', else the sole port) and selector are derived from it.
+  //
+  // Minimal usage (no overrides needed for a stencil service with a 'metrics'
+  // port):
+  // ```
+  // servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+  //   target_service:: $.service,
+  // },
+  // ```
+  //
+  // Common overrides:
+  // ```
+  // servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+  //   target_service:: $.service,
+  //   // drop noisy series; central rules are always appended last
+  //   centralMetricRelabelings:: [
+  //     { sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' },
+  //   ],
+  //   spec+: {
+  //     // per-endpoint tuning, keyed by the Service port's targetPort
+  //     endpoints_+:: { 'http-prom': { interval: '30s' } },
+  //     // copy an extra Service label onto every series (default: ['app'])
+  //     targetLabels_:: ['app', 'reporting_team'],
+  //   },
+  // },
+  // ```
   ServiceMonitor(name, namespace, app=name): $._Object(
     'monitoring.coreos.com/v1',
     'ServiceMonitor',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -800,13 +800,13 @@ local environment = std.extVar('environment');
   // ```
   // servicemonitor: ok.ServiceMonitor(app.name, app.namespace, interval='60s') {
   //   target_service:: $.service,
-  //   // drop noisy series; central rules are always appended last
-  //   centralMetricRelabelings:: [
-  //     { sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' },
-  //   ],
   //   spec+: {
   //     // per-endpoint tuning, keyed by the Service port's targetPort
-  //     endpoints_+:: { 'http-prom': { interval: '15s' } },
+  //     endpoints_+:: { 'http-prom': {
+  //       interval: '15s',
+  //       // drop noisy series
+  //       metricRelabelings: [{ sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' }],
+  //     } },
   //     // restrict which Service labels are copied (default: all of them)
   //     targetLabels_:: ['app', 'repo'],
   //   },
@@ -841,12 +841,6 @@ local environment = std.extVar('environment');
       // sorting could pick e.g. the gRPC port). Set spec.endpoints_ explicitly.
       else error 'ServiceMonitor(%s): target_service has multiple ports and none is named or targets "metrics"; set spec.endpoints_ explicitly' % name,
 
-    // Central metric_relabel_configs applied to every endpoint, appended AFTER
-    // any caller-supplied rules so platform-wide cardinality/cost guardrails
-    // cannot be dropped by a team's endpoints_ entry. Populate cluster-wide
-    // drop/keep rules here.
-    centralMetricRelabelings:: [],
-
     spec: {
       // All Service labels are copied onto every scraped series -- they carry
       // the low-cardinality dimensions (repo/bento/reporting_team/...) that
@@ -863,11 +857,7 @@ local environment = std.extVar('environment');
       endpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
         // per-endpoint via endpoints_.
-        local base = { honorLabels: true, interval: interval, targetPort: p } + this.spec.endpoints_[p];
-        local metricRelabelings =
-          (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
-          + this.centralMetricRelabelings;
-        base + (if std.length(metricRelabelings) > 0 then { metricRelabelings: metricRelabelings } else {})
+        { honorLabels: true, interval: interval, targetPort: p } + this.spec.endpoints_[p]
         for p in std.objectFields(this.spec.endpoints_)
       ],
       jobLabel: 'app',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -793,32 +793,67 @@ local environment = std.extVar('environment');
 
     local this = self,
 
-    // discover metrics port if exists, else use first port
-    // whatever this resolves to is only used as the default
-    // if spec.endpoints|spec.endpoints_ aren't specified below
-    local default_port = (
-      local ports = this.target_service.spec.ports;
-      std.filter(function(p) std.setMember('metrics', [p.name, p.targetPort]), ports)
-      + this.target_service.spec.ports
-    )[0],
+    // Discover the port to scrape.
+    // Note: use std.member, not std.setMember -- the latter assumes a sorted
+    // set and misdetects when targetPort == 'metrics' but the port name sorts
+    // after 'metrics'.
+    local ports = this.target_service.spec.ports,
+    local matched_ports = std.filter(
+      function(p) std.member([p.name, p.targetPort], 'metrics'),
+      ports,
+    ),
+    local default_port =
+      if std.length(matched_ports) > 0 then matched_ports[0]
+      // No 'metrics' port: fall back to the sole port when unambiguous
+      // (common for apps serving /metrics on their only port).
+      else if std.length(ports) == 1 then ports[0]
+      // Multiple ports and none is 'metrics' -> refuse to guess (objectFields
+      // sorting could pick e.g. the gRPC port). Set spec.endpoints_ explicitly.
+      else error 'ServiceMonitor(%s): target_service has multiple ports and none is named or targets "metrics"; set spec.endpoints_ explicitly' % name,
 
-    metadata+: { labels+: { 'prometheus.io/scrape': 'true' } },
+    // Central metric_relabel_configs applied to every endpoint, appended AFTER
+    // any caller-supplied rules so platform-wide cardinality/cost guardrails
+    // cannot be dropped by a team's endpoints_ entry. Populate cluster-wide
+    // drop/keep rules here.
+    centralMetricRelabelings:: [],
+
+    // Marker label the OTel Target Allocator's serviceMonitorSelector keys off.
+    // Keep in sync with the collector's
+    // targetAllocator.prometheusCR.serviceMonitorSelector.
+    scrapeLabels_:: { 'monitoring.outreach.io/otel-scrape': 'true' },
+
+    metadata+: { labels+: this.scrapeLabels_ },
     spec: {
+      // Labels copied from the target Service onto every scraped series. Keep
+      // this minimal -- each entry multiplies label cardinality (and storage)
+      // across all metrics. Extend via targetLabels_ when a label is needed.
+      targetLabels_:: ['app'],
+
       // endpoint-level config here will override defaults
       // this is just map-based sugar around self.endpoints
       endpoints_:: { [default_port.targetPort]: {} },
       // override this to explicitly adhere to the operator's API
       // and ignore all of the above, which is simply sugar
       endpoints: [
-        { honorLabels: true, interval: '1m', targetPort: p }
-        + this.spec.endpoints_[p]
+        // honorLabels defaults to false: app-exposed labels must not clobber
+        // topology labels (job/namespace/instance) or the jobLabel below.
+        local base = { honorLabels: false, interval: '1m', targetPort: p } + this.spec.endpoints_[p];
+        local metricRelabelings =
+          (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
+          + this.centralMetricRelabelings;
+        base + (if std.length(metricRelabelings) > 0 then { metricRelabelings: metricRelabelings } else {})
         for p in std.objectFields(this.spec.endpoints_)
       ],
       jobLabel: 'app',
+      // Minimal, stable selector -- match only the target Service's identity.
+      // The old default matched the full label set, which would silently break
+      // the SM if any label (repo/bento/reporting_team/...) changed. Override
+      // via selectorLabels_ if a different match is needed.
+      selectorLabels_:: { name: this.target_service.metadata.name },
       selector: {
-        matchLabels: this.target_service.metadata.labels,
+        matchLabels: this.spec.selectorLabels_,
       },
-      targetLabels: std.objectFields(this.target_service.metadata.labels),
+      targetLabels: this.spec.targetLabels_,
     },
   },
 

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -784,7 +784,9 @@ local environment = std.extVar('environment');
 
   // ServiceMonitor selects a Service and scrapes its metrics port. Pass the
   // target Service via target_service:: -- the metrics port (named or targeting
-  // 'metrics', else the sole port) and selector are derived from it.
+  // 'metrics', else the sole port) and selector are derived from it. All
+  // Service labels are copied onto the series; scrape interval defaults to 30s
+  // (override via the `interval` arg).
   //
   // Minimal usage (no overrides needed for a stencil service with a 'metrics'
   // port):
@@ -796,7 +798,7 @@ local environment = std.extVar('environment');
   //
   // Common overrides:
   // ```
-  // servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+  // servicemonitor: ok.ServiceMonitor(app.name, app.namespace, interval='60s') {
   //   target_service:: $.service,
   //   // drop noisy series; central rules are always appended last
   //   centralMetricRelabelings:: [
@@ -804,13 +806,13 @@ local environment = std.extVar('environment');
   //   ],
   //   spec+: {
   //     // per-endpoint tuning, keyed by the Service port's targetPort
-  //     endpoints_+:: { 'http-prom': { interval: '30s' } },
-  //     // copy an extra Service label onto every series (default: ['app'])
-  //     targetLabels_:: ['app', 'reporting_team'],
+  //     endpoints_+:: { 'http-prom': { interval: '15s' } },
+  //     // restrict which Service labels are copied (default: all of them)
+  //     targetLabels_:: ['app', 'repo'],
   //   },
   // },
   // ```
-  ServiceMonitor(name, namespace, app=name): $._Object(
+  ServiceMonitor(name, namespace, app=name, interval='30s'): $._Object(
     'monitoring.coreos.com/v1',
     'ServiceMonitor',
     name,
@@ -845,17 +847,13 @@ local environment = std.extVar('environment');
     // drop/keep rules here.
     centralMetricRelabelings:: [],
 
-    // Marker label the OTel Target Allocator's serviceMonitorSelector keys off.
-    // Keep in sync with the collector's
-    // targetAllocator.prometheusCR.serviceMonitorSelector.
-    scrapeLabels_:: { 'monitoring.outreach.io/otel-scrape': 'true' },
-
-    metadata+: { labels+: this.scrapeLabels_ },
     spec: {
-      // Labels copied from the target Service onto every scraped series. Keep
-      // this minimal -- each entry multiplies label cardinality (and storage)
-      // across all metrics. Extend via targetLabels_ when a label is needed.
-      targetLabels_:: ['app'],
+      // All Service labels are copied onto every scraped series -- they carry
+      // the low-cardinality dimensions (repo/bento/reporting_team/...) that
+      // downstream consumers rely on, and this is the only place to surface
+      // them. Any renames (e.g. reporting_team -> team) are done centrally in
+      // the collector pipeline, not here. Override targetLabels_ to restrict.
+      targetLabels_:: std.objectFields(this.target_service.metadata.labels),
 
       // endpoint-level config here will override defaults
       // this is just map-based sugar around self.endpoints
@@ -863,9 +861,9 @@ local environment = std.extVar('environment');
       // override this to explicitly adhere to the operator's API
       // and ignore all of the above, which is simply sugar
       endpoints: [
-        // honorLabels defaults to false: app-exposed labels must not clobber
-        // topology labels (job/namespace/instance) or the jobLabel below.
-        local base = { honorLabels: false, interval: '1m', targetPort: p } + this.spec.endpoints_[p];
+        // interval defaults to the constructor's `interval` arg (30s); override
+        // per-endpoint via endpoints_.
+        local base = { honorLabels: true, interval: interval, targetPort: p } + this.spec.endpoints_[p];
         local metricRelabelings =
           (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
           + this.centralMetricRelabelings;

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -28,7 +28,7 @@ assert std.length(resources.deployment.spec.template.spec.containers_.test.envFr
 assert std.objectHas(resources.deployment.spec.template.spec.containers_.test.envFrom[1], 'secretRef');
 assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secretRef == { name: 'secret' };
 
-// ServiceMonitor: metrics-port discovery, defaults, and central metric relabelings.
+// ServiceMonitor: metrics-port discovery, defaults, and relabelings.
 local svc = {
   metadata: { name: 'test', namespace: 'test', labels: {
     name: 'test', app: 'test', repo: 'test', reporting_team: 'fnd-pc',
@@ -77,15 +77,13 @@ assert std.length(smSinglePort.spec.endpoints) == 1;
 assert smSinglePort.spec.endpoints[0].targetPort == 'http';
 assert smSinglePort.spec.endpoints[0].interval == '15s';
 
-// central rules run last; caller rules (via endpoints_) run first.
+// per-endpoint metricRelabelings pass through via endpoints_.
 local smRelabel = k.ServiceMonitor('test', 'test') {
   target_service:: svc,
-  centralMetricRelabelings:: [{ regex: 'central', action: 'drop' }],
   spec+: { endpoints_:: { metrics: { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
 };
 assert smRelabel.spec.endpoints[0].metricRelabelings == [
   { regex: 'team', action: 'keep' },
-  { regex: 'central', action: 'drop' },
 ];
 
 resources

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -28,4 +28,56 @@ assert std.length(resources.deployment.spec.template.spec.containers_.test.envFr
 assert std.objectHas(resources.deployment.spec.template.spec.containers_.test.envFrom[1], 'secretRef');
 assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secretRef == { name: 'secret' };
 
+// ServiceMonitor: metrics-port discovery, defaults, and central metric relabelings.
+local svc = {
+  metadata: { name: 'test', namespace: 'test', labels: { name: 'test', app: 'test' } },
+  spec: { ports: [
+    { name: 'grpc', port: 5000, targetPort: 'grpc' },
+    // targetPort 'metrics' with a name that sorts after it: exercises the
+    // std.member fix (std.setMember misdetected this as absent).
+    { name: 'zzz', port: 8000, targetPort: 'metrics' },
+  ] },
+};
+
+local sm = k.ServiceMonitor('test', 'test') { target_service:: svc };
+assert std.length(sm.spec.endpoints) == 1;
+// port discovered by targetPort == 'metrics' regardless of name ordering
+assert sm.spec.endpoints[0].targetPort == 'metrics';
+// honorLabels defaults to false so app labels can't clobber topology labels
+assert sm.spec.endpoints[0].honorLabels == false;
+// no relabelings by default -> key omitted (clean output)
+assert !std.objectHas(sm.spec.endpoints[0], 'metricRelabelings');
+// targetLabels is a minimal allowlist, not every Service label
+assert sm.spec.targetLabels == ['app'];
+// selector matches only the Service identity, not the full label set
+assert sm.spec.selector.matchLabels == { name: 'test' };
+// carries the OTel Target Allocator marker label (not prometheus.io/scrape)
+assert sm.metadata.labels['monitoring.outreach.io/otel-scrape'] == 'true';
+assert !std.objectHas(sm.metadata.labels, 'prometheus.io/scrape');
+
+// single-port service with no 'metrics' port falls back to that sole port
+// (apps serving /metrics on their only port, e.g. via endpoints_ override).
+local svcSinglePort = {
+  metadata: { name: 'test', namespace: 'test', labels: { name: 'test', app: 'test' } },
+  spec: { ports: [{ name: 'http', port: 8000, targetPort: 'http' }] },
+};
+local smSinglePort = k.ServiceMonitor('test', 'test') {
+  target_service:: svcSinglePort,
+  spec+: { endpoints_+:: { http+: { interval: '15s' } } },
+};
+assert std.length(smSinglePort.spec.endpoints) == 1;
+assert smSinglePort.spec.endpoints[0].targetPort == 'http';
+assert smSinglePort.spec.endpoints[0].interval == '15s';
+
+// central rules run last; caller rules (via endpoints_) run first.
+local smRelabel = k.ServiceMonitor('test', 'test') {
+  target_service:: svc,
+  centralMetricRelabelings:: [{ regex: 'central', action: 'drop' }],
+  spec+: { endpoints_:: { metrics: { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
+};
+assert smRelabel.spec.endpoints[0].metricRelabelings == [
+  { regex: 'team', action: 'keep' },
+  { regex: 'central', action: 'drop' },
+];
+
 resources

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -30,7 +30,9 @@ assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secre
 
 // ServiceMonitor: metrics-port discovery, defaults, and central metric relabelings.
 local svc = {
-  metadata: { name: 'test', namespace: 'test', labels: { name: 'test', app: 'test' } },
+  metadata: { name: 'test', namespace: 'test', labels: {
+    name: 'test', app: 'test', repo: 'test', reporting_team: 'fnd-pc',
+  } },
   spec: { ports: [
     { name: 'grpc', port: 5000, targetPort: 'grpc' },
     // targetPort 'metrics' with a name that sorts after it: exercises the
@@ -43,17 +45,23 @@ local sm = k.ServiceMonitor('test', 'test') { target_service:: svc };
 assert std.length(sm.spec.endpoints) == 1;
 // port discovered by targetPort == 'metrics' regardless of name ordering
 assert sm.spec.endpoints[0].targetPort == 'metrics';
-// honorLabels defaults to false so app labels can't clobber topology labels
-assert sm.spec.endpoints[0].honorLabels == false;
+// honorLabels defaults to true
+assert sm.spec.endpoints[0].honorLabels == true;
+// interval defaults to 30s
+assert sm.spec.endpoints[0].interval == '30s';
 // no relabelings by default -> key omitted (clean output)
 assert !std.objectHas(sm.spec.endpoints[0], 'metricRelabelings');
-// targetLabels is a minimal allowlist, not every Service label
-assert sm.spec.targetLabels == ['app'];
+// all Service labels are copied onto the series (not filtered)
+assert sm.spec.targetLabels == ['app', 'name', 'repo', 'reporting_team'];
 // selector matches only the Service identity, not the full label set
 assert sm.spec.selector.matchLabels == { name: 'test' };
-// carries the OTel Target Allocator marker label (not prometheus.io/scrape)
-assert sm.metadata.labels['monitoring.outreach.io/otel-scrape'] == 'true';
+// no scrape marker label (TA selector is open; the label only confused readers)
+assert !std.objectHas(sm.metadata.labels, 'monitoring.outreach.io/otel-scrape');
 assert !std.objectHas(sm.metadata.labels, 'prometheus.io/scrape');
+
+// interval is overridable via the constructor arg
+local smInterval = k.ServiceMonitor('test', 'test', interval='60s') { target_service:: svc };
+assert smInterval.spec.endpoints[0].interval == '60s';
 
 // single-port service with no 'metrics' port falls back to that sole port
 // (apps serving /metrics on their only port, e.g. via endpoints_ override).


### PR DESCRIPTION
## Summary

Hardens the `ServiceMonitor` constructor in `kubernetes/kube.libsonnet`: fixes a latent metrics-port detection bug, fails loudly on ambiguous port config, narrows the selector, and makes the scrape interval a parameter. Metric-shaping defaults (labels, honorLabels) are left at their permissive values on purpose — see below.

## Usage

Minimal (stencil service with a `metrics` port):

```jsonnet
servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
  target_service:: $.service,
},
```

With overrides (all optional):

```jsonnet
servicemonitor: ok.ServiceMonitor(app.name, app.namespace, interval='60s') {
  target_service:: $.service,
  spec+: {
    endpoints_+:: { 'http-prom': {
      interval: '15s',                                                              // per-endpoint tuning, keyed by targetPort
      metricRelabelings: [{ sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' }],  // drop noisy series
    } },
    targetLabels_:: ['app', 'repo'],                                                // restrict copied labels (default: all)
  },
},
```

## Changes

| # | Change | Why |
|---|--------|-----|
| 1 | Port detection uses `std.member`, not `std.setMember` | `setMember` binary-searches an assumed-sorted set; on the unsorted `[p.name, p.targetPort]` it misdetected a port with `targetPort: metrics` whose `name` sorts after `metrics`. |
| 2 | No `metrics` port → sole-port fallback, else **error** | The old code fell back to `spec.ports[0]` (alphabetically first — could be gRPC). Single-port services still work; multi-port-no-metrics now fails loudly. Override with `spec.endpoints_`. |
| 3 | `selector.matchLabels` → `{ name: <svc> }` (via `selectorLabels_::`) | Old default matched the full label set, silently breaking if any label changed. |
| 4 | Scrape `interval` is a constructor arg, default `30s` | Was hardcoded `1m`. Still overridable per-endpoint via `endpoints_`. |
| 5 | Removed the `prometheus.io/scrape` label | The Target Allocator's `serviceMonitorSelector` is open (match-all), so the label selected nothing and only confused readers. |

**Left permissive on purpose:** `targetLabels` copies **all** Service labels onto the series (low-cardinality dimensions like `repo`/`bento`/`reporting_team` that downstream consumers need — this is the only place to surface them), and `honorLabels` stays `true`. Label renames (e.g. `reporting_team → team`) are handled **centrally in the collector pipeline**, not per-ServiceMonitor. Per-endpoint `metricRelabelings` pass through via `endpoints_`.

## Compatibility

Stencil-golang always emits a `metrics`-named Service port, so default detection works for every current/future stencil service; the two live callers (`ds-mlflow-project-proxy`, `tokenauthenticator`) are single-port and covered by the fallback. Verified both still render.

## Testing

`tests/kube.jsonnet` covers port discovery (the `std.member` edge case), single-port fallback, `honorLabels == true`, `interval == 30s` (+ override), copy-all `targetLabels`, `{ name }` selector, absence of any scrape marker label, and per-endpoint `metricRelabelings` pass-through. `make test` passes; no snapshot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
