### PR TITLE
feat: add PodMonitor constructor for serviceless metrics scraping

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -827,7 +827,29 @@ local environment = std.extVar('environment');
   // honorLabels off, a minimal podTargetLabels allowlist, an OTel Target
   // Allocator marker label, and a central metric-relabeling hook.
   //
-  // Pass the workload's pod template, e.g. target_pod:: $.deployment.spec.template.
+  // Minimal usage (pod has a 'metrics'/'http-prom' container port):
+  // ```
+  // podmonitor: ok.PodMonitor(app.name, app.namespace) {
+  //   target_pod:: $.deployment.spec.template,
+  // },
+  // ```
+  //
+  // Common overrides:
+  // ```
+  // podmonitor: ok.PodMonitor(app.name, app.namespace) {
+  //   target_pod:: $.deployment.spec.template,
+  //   // drop noisy series; central rules are always appended last
+  //   centralMetricRelabelings:: [
+  //     { sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' },
+  //   ],
+  //   spec+: {
+  //     // per-endpoint tuning, keyed by the container port name
+  //     podMetricsEndpoints_+:: { 'http-prom': { interval: '30s' } },
+  //     // copy an extra pod label onto every series (default: ['app'])
+  //     podTargetLabels_:: ['app', 'reporting_team'],
+  //   },
+  // },
+  // ```
   PodMonitor(name, namespace, app=name): $._Object(
     'monitoring.coreos.com/v1',
     'PodMonitor',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -824,8 +824,8 @@ local environment = std.extVar('environment');
 
   // PodMonitor scrapes pods directly, for apps that do not expose a Service
   // with a metrics port. Mirrors ServiceMonitor's defaults: minimal selector,
-  // honorLabels on, all pod labels copied onto the series, a 30s scrape
-  // interval, and a central metric-relabeling hook.
+  // honorLabels on, all pod labels copied onto the series, and a 30s scrape
+  // interval.
   //
   // Minimal usage (pod has a 'metrics'/'http-prom' container port):
   // ```
@@ -838,13 +838,13 @@ local environment = std.extVar('environment');
   // ```
   // podmonitor: ok.PodMonitor(app.name, app.namespace, interval='60s') {
   //   target_pod:: $.deployment.spec.template,
-  //   // drop noisy series; central rules are always appended last
-  //   centralMetricRelabelings:: [
-  //     { sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' },
-  //   ],
   //   spec+: {
   //     // per-endpoint tuning, keyed by the container port name
-  //     podMetricsEndpoints_+:: { 'http-prom': { interval: '15s' } },
+  //     podMetricsEndpoints_+:: { 'http-prom': {
+  //       interval: '15s',
+  //       // drop noisy series before they leave the pod
+  //       metricRelabelings: [{ sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' }],
+  //     } },
   //     // restrict which pod labels are copied (default: all of them)
   //     podTargetLabels_:: ['app', 'repo'],
   //   },
@@ -879,11 +879,6 @@ local environment = std.extVar('environment');
       // Multiple ports and none is a metrics port -> refuse to guess.
       else error 'PodMonitor(%s): target_pod has multiple ports and none is named one of [%s]; set spec.podMetricsEndpoints_ explicitly' % [name, std.join(', ', metrics_port_names)],
 
-    // Central metric_relabel_configs applied to every endpoint, appended AFTER
-    // caller-supplied rules so platform-wide guardrails can't be dropped by a
-    // team's podMetricsEndpoints_ entry.
-    centralMetricRelabelings:: [],
-
     spec: {
       // All pod labels are copied onto every scraped series -- they carry the
       // low-cardinality dimensions (repo/bento/reporting_team/...) that
@@ -898,11 +893,7 @@ local environment = std.extVar('environment');
       podMetricsEndpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
         // per-endpoint via podMetricsEndpoints_.
-        local base = { honorLabels: true, interval: interval, port: p } + this.spec.podMetricsEndpoints_[p];
-        local metricRelabelings =
-          (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
-          + this.centralMetricRelabelings;
-        base + (if std.length(metricRelabelings) > 0 then { metricRelabelings: metricRelabelings } else {})
+        { honorLabels: true, interval: interval, port: p } + this.spec.podMetricsEndpoints_[p]
         for p in std.objectFields(this.spec.podMetricsEndpoints_)
       ],
       jobLabel: 'app',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -822,6 +822,82 @@ local environment = std.extVar('environment');
     },
   },
 
+  // PodMonitor scrapes pods directly, for apps that do not expose a Service
+  // with a metrics port. Mirrors ServiceMonitor's defaults: minimal selector,
+  // honorLabels off, a minimal podTargetLabels allowlist, an OTel Target
+  // Allocator marker label, and a central metric-relabeling hook.
+  //
+  // Pass the workload's pod template, e.g. target_pod:: $.deployment.spec.template.
+  PodMonitor(name, namespace, app=name): $._Object(
+    'monitoring.coreos.com/v1',
+    'PodMonitor',
+    name,
+    app=app,
+    namespace=namespace,
+  ) {
+    target_pod:: error 'target_pod required',
+
+    local this = self,
+
+    // Flatten every container port on the pod. Container ports have a name and
+    // containerPort (no targetPort -- that only exists on Services).
+    local pod_ports = std.flattenArrays([
+      if std.objectHas(c, 'ports') then c.ports else []
+      for c in this.target_pod.spec.containers
+    ]),
+    // Container port names that identify the metrics port. Note this is the
+    // CONTAINER port name: stencil names it 'http-prom' (the Service port named
+    // 'metrics' targets it), so match both.
+    local metrics_port_names = ['metrics', 'http-prom'],
+    local matched_ports = std.filter(function(p) std.member(metrics_port_names, p.name), pod_ports),
+    local default_port =
+      if std.length(matched_ports) > 0 then matched_ports[0]
+      // No metrics-named port: fall back to the sole port when unambiguous.
+      else if std.length(pod_ports) == 1 then pod_ports[0]
+      // Multiple ports and none is a metrics port -> refuse to guess.
+      else error 'PodMonitor(%s): target_pod has multiple ports and none is named one of [%s]; set spec.podMetricsEndpoints_ explicitly' % [name, std.join(', ', metrics_port_names)],
+
+    // Central metric_relabel_configs applied to every endpoint, appended AFTER
+    // caller-supplied rules so platform-wide guardrails can't be dropped by a
+    // team's podMetricsEndpoints_ entry.
+    centralMetricRelabelings:: [],
+
+    // Marker label the OTel Target Allocator's podMonitorSelector keys off.
+    // Keep in sync with the collector's
+    // targetAllocator.prometheusCR.podMonitorSelector.
+    scrapeLabels_:: { 'monitoring.outreach.io/otel-scrape': 'true' },
+
+    metadata+: { labels+: this.scrapeLabels_ },
+    spec: {
+      // Pod labels copied onto every scraped series. Keep minimal -- each entry
+      // multiplies cardinality (and storage). Extend via podTargetLabels_.
+      podTargetLabels_:: ['app'],
+
+      // map-based sugar around self.podMetricsEndpoints, keyed by port name
+      podMetricsEndpoints_:: { [default_port.name]: {} },
+      // override this to explicitly adhere to the operator's API
+      podMetricsEndpoints: [
+        // honorLabels defaults to false: app-exposed labels must not clobber
+        // topology labels (job/namespace/pod) or the jobLabel below.
+        local base = { honorLabels: false, interval: '1m', port: p } + this.spec.podMetricsEndpoints_[p];
+        local metricRelabelings =
+          (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
+          + this.centralMetricRelabelings;
+        base + (if std.length(metricRelabelings) > 0 then { metricRelabelings: metricRelabelings } else {})
+        for p in std.objectFields(this.spec.podMetricsEndpoints_)
+      ],
+      jobLabel: 'app',
+      // Minimal, stable selector against the pod's identity label. Override via
+      // selectorLabels_ if a different match is needed. (namespaceSelector is
+      // omitted so the operator defaults to the PodMonitor's own namespace.)
+      selectorLabels_:: { name: this.target_pod.metadata.labels.name },
+      selector: {
+        matchLabels: this.spec.selectorLabels_,
+      },
+      podTargetLabels: this.spec.podTargetLabels_,
+    },
+  },
+
   Mixins: {
     'cluster-service': {
       metadata+: {

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -824,8 +824,8 @@ local environment = std.extVar('environment');
 
   // PodMonitor scrapes pods directly, for apps that do not expose a Service
   // with a metrics port. Mirrors ServiceMonitor's defaults: minimal selector,
-  // honorLabels off, a minimal podTargetLabels allowlist, an OTel Target
-  // Allocator marker label, and a central metric-relabeling hook.
+  // honorLabels on, all pod labels copied onto the series, a 30s scrape
+  // interval, and a central metric-relabeling hook.
   //
   // Minimal usage (pod has a 'metrics'/'http-prom' container port):
   // ```
@@ -836,7 +836,7 @@ local environment = std.extVar('environment');
   //
   // Common overrides:
   // ```
-  // podmonitor: ok.PodMonitor(app.name, app.namespace) {
+  // podmonitor: ok.PodMonitor(app.name, app.namespace, interval='60s') {
   //   target_pod:: $.deployment.spec.template,
   //   // drop noisy series; central rules are always appended last
   //   centralMetricRelabelings:: [
@@ -844,13 +844,13 @@ local environment = std.extVar('environment');
   //   ],
   //   spec+: {
   //     // per-endpoint tuning, keyed by the container port name
-  //     podMetricsEndpoints_+:: { 'http-prom': { interval: '30s' } },
-  //     // copy an extra pod label onto every series (default: ['app'])
-  //     podTargetLabels_:: ['app', 'reporting_team'],
+  //     podMetricsEndpoints_+:: { 'http-prom': { interval: '15s' } },
+  //     // restrict which pod labels are copied (default: all of them)
+  //     podTargetLabels_:: ['app', 'repo'],
   //   },
   // },
   // ```
-  PodMonitor(name, namespace, app=name): $._Object(
+  PodMonitor(name, namespace, app=name, interval='30s'): $._Object(
     'monitoring.coreos.com/v1',
     'PodMonitor',
     name,
@@ -884,24 +884,21 @@ local environment = std.extVar('environment');
     // team's podMetricsEndpoints_ entry.
     centralMetricRelabelings:: [],
 
-    // Marker label the OTel Target Allocator's podMonitorSelector keys off.
-    // Keep in sync with the collector's
-    // targetAllocator.prometheusCR.podMonitorSelector.
-    scrapeLabels_:: { 'monitoring.outreach.io/otel-scrape': 'true' },
-
-    metadata+: { labels+: this.scrapeLabels_ },
     spec: {
-      // Pod labels copied onto every scraped series. Keep minimal -- each entry
-      // multiplies cardinality (and storage). Extend via podTargetLabels_.
-      podTargetLabels_:: ['app'],
+      // All pod labels are copied onto every scraped series -- they carry the
+      // low-cardinality dimensions (repo/bento/reporting_team/...) that
+      // downstream consumers rely on. Any renames (e.g. reporting_team -> team)
+      // are done centrally in the collector pipeline, not here. Override
+      // podTargetLabels_ to restrict the set.
+      podTargetLabels_:: std.objectFields(this.target_pod.metadata.labels),
 
       // map-based sugar around self.podMetricsEndpoints, keyed by port name
       podMetricsEndpoints_:: { [default_port.name]: {} },
       // override this to explicitly adhere to the operator's API
       podMetricsEndpoints: [
-        // honorLabels defaults to false: app-exposed labels must not clobber
-        // topology labels (job/namespace/pod) or the jobLabel below.
-        local base = { honorLabels: false, interval: '1m', port: p } + this.spec.podMetricsEndpoints_[p];
+        // interval defaults to the constructor's `interval` arg (30s); override
+        // per-endpoint via podMetricsEndpoints_.
+        local base = { honorLabels: true, interval: interval, port: p } + this.spec.podMetricsEndpoints_[p];
         local metricRelabelings =
           (if std.objectHas(base, 'metricRelabelings') then base.metricRelabelings else [])
           + this.centralMetricRelabelings;

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -31,7 +31,7 @@ assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secre
 // PodMonitor: metrics-port discovery from container ports, defaults, hooks.
 // Stencil-shaped pod: metrics container port is named 'http-prom' (not 'metrics').
 local podTmpl = {
-  metadata: { labels: { name: 'test', app: 'test' } },
+  metadata: { labels: { name: 'test', app: 'test', repo: 'test', reporting_team: 'fnd-pc' } },
   spec: { containers: [{ name: 'default', ports: [
     { name: 'grpc', containerPort: 5000 },
     { name: 'http-prom', containerPort: 8000 },
@@ -42,11 +42,20 @@ local pm = k.PodMonitor('test', 'test') { target_pod:: podTmpl };
 assert std.length(pm.spec.podMetricsEndpoints) == 1;
 // 'http-prom' discovered even though no port is named 'metrics'
 assert pm.spec.podMetricsEndpoints[0].port == 'http-prom';
-assert pm.spec.podMetricsEndpoints[0].honorLabels == false;
+// honorLabels defaults to true
+assert pm.spec.podMetricsEndpoints[0].honorLabels == true;
+// interval defaults to 30s
+assert pm.spec.podMetricsEndpoints[0].interval == '30s';
 assert !std.objectHas(pm.spec.podMetricsEndpoints[0], 'metricRelabelings');
-assert pm.spec.podTargetLabels == ['app'];
+// all pod labels are copied onto the series (not filtered)
+assert pm.spec.podTargetLabels == ['app', 'name', 'repo', 'reporting_team'];
 assert pm.spec.selector.matchLabels == { name: 'test' };
-assert pm.metadata.labels['monitoring.outreach.io/otel-scrape'] == 'true';
+// no scrape marker label (TA selector is open)
+assert !std.objectHas(pm.metadata.labels, 'monitoring.outreach.io/otel-scrape');
+
+// interval is overridable via the constructor arg
+local pmInterval = k.PodMonitor('test', 'test', interval='60s') { target_pod:: podTmpl };
+assert pmInterval.spec.podMetricsEndpoints[0].interval == '60s';
 
 // single-port pod with no metrics-named port falls back to that sole port.
 local pmSingle = k.PodMonitor('test', 'test') {

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -28,4 +28,42 @@ assert std.length(resources.deployment.spec.template.spec.containers_.test.envFr
 assert std.objectHas(resources.deployment.spec.template.spec.containers_.test.envFrom[1], 'secretRef');
 assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secretRef == { name: 'secret' };
 
+// PodMonitor: metrics-port discovery from container ports, defaults, hooks.
+// Stencil-shaped pod: metrics container port is named 'http-prom' (not 'metrics').
+local podTmpl = {
+  metadata: { labels: { name: 'test', app: 'test' } },
+  spec: { containers: [{ name: 'default', ports: [
+    { name: 'grpc', containerPort: 5000 },
+    { name: 'http-prom', containerPort: 8000 },
+    { name: 'http', containerPort: 8080 },
+  ] }] },
+};
+local pm = k.PodMonitor('test', 'test') { target_pod:: podTmpl };
+assert std.length(pm.spec.podMetricsEndpoints) == 1;
+// 'http-prom' discovered even though no port is named 'metrics'
+assert pm.spec.podMetricsEndpoints[0].port == 'http-prom';
+assert pm.spec.podMetricsEndpoints[0].honorLabels == false;
+assert !std.objectHas(pm.spec.podMetricsEndpoints[0], 'metricRelabelings');
+assert pm.spec.podTargetLabels == ['app'];
+assert pm.spec.selector.matchLabels == { name: 'test' };
+assert pm.metadata.labels['monitoring.outreach.io/otel-scrape'] == 'true';
+
+// single-port pod with no metrics-named port falls back to that sole port.
+local pmSingle = k.PodMonitor('test', 'test') {
+  target_pod:: { metadata: { labels: { name: 'test', app: 'test' } },
+                 spec: { containers: [{ name: 'c', ports: [{ name: 'web', containerPort: 9000 }] }] } },
+};
+assert pmSingle.spec.podMetricsEndpoints[0].port == 'web';
+
+// central rules run last; caller rules (via podMetricsEndpoints_) run first.
+local pmRelabel = k.PodMonitor('test', 'test') {
+  target_pod:: podTmpl,
+  centralMetricRelabelings:: [{ regex: 'central', action: 'labeldrop' }],
+  spec+: { podMetricsEndpoints_+:: { 'http-prom': { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
+};
+assert pmRelabel.spec.podMetricsEndpoints[0].metricRelabelings == [
+  { regex: 'team', action: 'keep' },
+  { regex: 'central', action: 'labeldrop' },
+];
+
 resources

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -64,15 +64,13 @@ local pmSingle = k.PodMonitor('test', 'test') {
 };
 assert pmSingle.spec.podMetricsEndpoints[0].port == 'web';
 
-// central rules run last; caller rules (via podMetricsEndpoints_) run first.
+// per-endpoint metricRelabelings pass through via podMetricsEndpoints_.
 local pmRelabel = k.PodMonitor('test', 'test') {
   target_pod:: podTmpl,
-  centralMetricRelabelings:: [{ regex: 'central', action: 'labeldrop' }],
   spec+: { podMetricsEndpoints_+:: { 'http-prom': { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
 };
 assert pmRelabel.spec.podMetricsEndpoints[0].metricRelabelings == [
   { regex: 'team', action: 'keep' },
-  { regex: 'central', action: 'labeldrop' },
 ];
 
 resources


### PR DESCRIPTION
## Summary

Adds a `PodMonitor` constructor to `kubernetes/kube.libsonnet` for apps that expose a `/metrics` **container port but no Service** with a metrics target — those can't be selected by a `ServiceMonitor`. It scrapes pods directly and mirrors the `ServiceMonitor` conventions (see #320).

## Usage

Minimal (pod has a `metrics`/`http-prom` container port):

```jsonnet
podmonitor: ok.PodMonitor(app.name, app.namespace) {
  target_pod:: $.deployment.spec.template,
},
```

With overrides (all optional):

```jsonnet
podmonitor: ok.PodMonitor(app.name, app.namespace, interval='60s') {
  target_pod:: $.deployment.spec.template,
  spec+: {
    podMetricsEndpoints_+:: { 'http-prom': {
      interval: '15s',                                                              // per-endpoint tuning, by container port name
      metricRelabelings: [{ sourceLabels: ['__name__'], regex: 'go_gc_.*', action: 'drop' }],
    } },
    podTargetLabels_:: ['app', 'repo'],                                             // restrict copied labels (default: all)
  },
},
```

## Design

| Aspect | Behavior |
|--------|----------|
| Port discovery | Flattens all container ports, matches the **container** port name against `['metrics', 'http-prom']` (stencil names the container metrics port `http-prom`; only the *Service* port is `metrics`). |
| Fallback | Sole port if exactly one; **error** on multiple ports with no metrics-named port (override with `podMetricsEndpoints_`). |
| `interval` | Constructor arg, default `30s`; overridable per-endpoint. |
| `honorLabels` | `true`. |
| `podTargetLabels` | Copies **all** pod labels onto the series; restrict via `podTargetLabels_::`. Renames handled centrally in the collector. |
| `selector.matchLabels` | `{ name: <pod> }` (via `selectorLabels_::`); `namespaceSelector` omitted → operator defaults to the PodMonitor's own namespace. |

No scrape marker label (the Target Allocator's `podMonitorSelector` is open / match-all). Per-endpoint `metricRelabelings` pass through via `podMetricsEndpoints_`.

## ServiceMonitor vs PodMonitor differences handled

- `spec.podMetricsEndpoints` (not `endpoints`); endpoints reference the pod port by **name** (`port:`), since container ports have no `targetPort`.
- `spec.podTargetLabels` copies **pod** labels; `spec.selector` matches **pod** labels.

## Testing

`tests/kube.jsonnet` covers `http-prom` discovery (the no-`metrics`-name case), single-port fallback, `honorLabels == true`, `interval == 30s` (+ override), copy-all `podTargetLabels`, `{ name }` selector, absence of any scrape marker label, and per-endpoint `metricRelabelings` pass-through. `make test` passes; no snapshot drift.

## Relationship to #320

Independent PR, branched from `master`; adds a new sibling function (no conflict if #320 merges first). Both share the same conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
