### PR TITLE
feat(kubernetes): stamp collection interval in seconds on ServiceMonitor/PodMonitor metrics

### DIFF
--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -782,6 +782,26 @@ local environment = std.extVar('environment');
     },
   },
 
+  // Convert a prometheus duration ('30s', '1m', '2h') to whole seconds.
+  // Single-unit durations only; compound forms like '1m30s' are rejected.
+  local durationSeconds(d) =
+    local n = std.parseInt(std.substr(d, 0, std.length(d) - 1));
+    local unit = std.substr(d, std.length(d) - 1, 1);
+    if unit == 's' then n
+    else if unit == 'm' then n * 60
+    else if unit == 'h' then n * 3600
+    else error 'unsupported interval %s: expected <n>s, <n>m, or <n>h' % d,
+
+  // Stamps the scrape interval (in seconds) onto every series scraped by an
+  // endpoint. The OTel collector maps it to a datapoint attribute and then
+  // promotes it to a resource attribute. Prometheus label names cannot contain
+  // dots, so the attribute name is underscore-flattened here and renamed in
+  // the collector pipeline.
+  local intervalRelabeling(interval) = {
+    targetLabel: 'outreach_metric_collection_interval',
+    replacement: std.toString(durationSeconds(interval)),
+  },
+
   // ServiceMonitor selects a Service and scrapes its metrics port. Pass the
   // target Service via target_service:: -- the metrics port (named or targeting
   // 'metrics', else the sole port) and selector are derived from it. All
@@ -854,26 +874,18 @@ local environment = std.extVar('environment');
       endpoints_:: { [default_port.targetPort]: {} },
       // override this to explicitly adhere to the operator's API
       // and ignore all of the above, which is simply sugar
-      // Map-based sugar around self.metricRelabelings. Key is an arbitrary
-      // rule name; use metricRelabelings_+:: to add/replace rules and let
-      // the array below do the conversion.
-      metricRelabelings_:: {
-        // Stamps the scrape interval (in seconds) onto every series. The OTel
-        // collector maps it to a datapoint attribute and then promotes it to a
-        // resource attribute. Prometheus label names cannot contain dots, so
-        // the attribute name is prefixed with underscores here and renamed in
-        // the collector pipeline.
-        'outreach.metric.collection_interval': { targetLabel: 'outreach_metric_collection_interval', replacement: std.toString(std.parseInt(std.substr(interval, 0, std.length(interval) - 1))) },
-      },
-      metricRelabelings: [
-        this.spec.metricRelabelings_[k]
-        for k in std.objectFields(this.spec.metricRelabelings_)
-      ],
-
       endpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
-        // per-endpoint via endpoints_.
-        { honorLabels: true, interval: interval, targetPort: p } + this.spec.endpoints_[p]
+        // per-endpoint via endpoints_. The interval stamp is derived from the
+        // endpoint's effective interval, so per-endpoint overrides are
+        // reflected in the label; user metricRelabelings are appended after
+        // the stamp. To suppress the stamp, override metricRelabelings on the
+        // rendered endpoint.
+        local ep = { honorLabels: true, interval: interval, targetPort: p } + this.spec.endpoints_[p];
+        ep {
+          metricRelabelings: [intervalRelabeling(ep.interval)]
+                             + (if std.objectHas(ep, 'metricRelabelings') then ep.metricRelabelings else []),
+        }
         for p in std.objectFields(this.spec.endpoints_)
       ],
       jobLabel: 'app',
@@ -957,26 +969,18 @@ local environment = std.extVar('environment');
       // map-based sugar around self.podMetricsEndpoints, keyed by port name
       podMetricsEndpoints_:: { [default_port.name]: {} },
       // override this to explicitly adhere to the operator's API
-      // Map-based sugar around self.metricRelabelings. Key is an arbitrary
-      // rule name; use metricRelabelings_+:: to add/replace rules and let
-      // the array below do the conversion.
-      metricRelabelings_:: {
-        // Stamps the scrape interval (in seconds) onto every series. The OTel
-        // collector maps it to a datapoint attribute and then promotes it to a
-        // resource attribute. Prometheus label names cannot contain dots, so
-        // the attribute name is prefixed with underscores here and renamed in
-        // the collector pipeline.
-        'outreach.metric.collection_interval': { targetLabel: 'outreach_metric_collection_interval', replacement: std.toString(std.parseInt(std.substr(interval, 0, std.length(interval) - 1))) },
-      },
-      metricRelabelings: [
-        this.spec.metricRelabelings_[k]
-        for k in std.objectFields(this.spec.metricRelabelings_)
-      ],
-
       podMetricsEndpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
-        // per-endpoint via podMetricsEndpoints_.
-        { honorLabels: true, interval: interval, port: p } + this.spec.podMetricsEndpoints_[p]
+        // per-endpoint via podMetricsEndpoints_. The interval stamp is derived
+        // from the endpoint's effective interval, so per-endpoint overrides
+        // are reflected in the label; user metricRelabelings are appended
+        // after the stamp. To suppress the stamp, override metricRelabelings
+        // on the rendered endpoint.
+        local ep = { honorLabels: true, interval: interval, port: p } + this.spec.podMetricsEndpoints_[p];
+        ep {
+          metricRelabelings: [intervalRelabeling(ep.interval)]
+                             + (if std.objectHas(ep, 'metricRelabelings') then ep.metricRelabelings else []),
+        }
         for p in std.objectFields(this.spec.podMetricsEndpoints_)
       ],
       jobLabel: 'app',

--- a/kubernetes/kube.libsonnet
+++ b/kubernetes/kube.libsonnet
@@ -854,6 +854,22 @@ local environment = std.extVar('environment');
       endpoints_:: { [default_port.targetPort]: {} },
       // override this to explicitly adhere to the operator's API
       // and ignore all of the above, which is simply sugar
+      // Map-based sugar around self.metricRelabelings. Key is an arbitrary
+      // rule name; use metricRelabelings_+:: to add/replace rules and let
+      // the array below do the conversion.
+      metricRelabelings_:: {
+        // Stamps the scrape interval (in seconds) onto every series. The OTel
+        // collector maps it to a datapoint attribute and then promotes it to a
+        // resource attribute. Prometheus label names cannot contain dots, so
+        // the attribute name is prefixed with underscores here and renamed in
+        // the collector pipeline.
+        'outreach.metric.collection_interval': { targetLabel: 'outreach_metric_collection_interval', replacement: std.toString(std.parseInt(std.substr(interval, 0, std.length(interval) - 1))) },
+      },
+      metricRelabelings: [
+        this.spec.metricRelabelings_[k]
+        for k in std.objectFields(this.spec.metricRelabelings_)
+      ],
+
       endpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
         // per-endpoint via endpoints_.
@@ -941,6 +957,22 @@ local environment = std.extVar('environment');
       // map-based sugar around self.podMetricsEndpoints, keyed by port name
       podMetricsEndpoints_:: { [default_port.name]: {} },
       // override this to explicitly adhere to the operator's API
+      // Map-based sugar around self.metricRelabelings. Key is an arbitrary
+      // rule name; use metricRelabelings_+:: to add/replace rules and let
+      // the array below do the conversion.
+      metricRelabelings_:: {
+        // Stamps the scrape interval (in seconds) onto every series. The OTel
+        // collector maps it to a datapoint attribute and then promotes it to a
+        // resource attribute. Prometheus label names cannot contain dots, so
+        // the attribute name is prefixed with underscores here and renamed in
+        // the collector pipeline.
+        'outreach.metric.collection_interval': { targetLabel: 'outreach_metric_collection_interval', replacement: std.toString(std.parseInt(std.substr(interval, 0, std.length(interval) - 1))) },
+      },
+      metricRelabelings: [
+        this.spec.metricRelabelings_[k]
+        for k in std.objectFields(this.spec.metricRelabelings_)
+      ],
+
       podMetricsEndpoints: [
         // interval defaults to the constructor's `interval` arg (30s); override
         // per-endpoint via podMetricsEndpoints_.
@@ -1060,14 +1092,14 @@ local environment = std.extVar('environment');
         protocol: 'HBONE',
       }],
       infrastructure+: {
-          parametersRef: {
-            group: '',
-            kind: 'ConfigMap',
-            name: name,
-          },
+        parametersRef: {
+          group: '',
+          kind: 'ConfigMap',
+          name: name,
         },
       },
     },
+  },
 
   WaypointProxyConfig(name='waypoint-config', namespace, team): self.ConfigMap(name, namespace, team) {
     metadata+: {
@@ -1105,18 +1137,18 @@ local environment = std.extVar('environment');
                 topologyKey: 'topology.kubernetes.io/zone',
                 whenUnsatisfiable: 'DoNotSchedule',
               }],
-                containers: [{
-                  name: 'istio-proxy',
-                  resources: {
-                    limits: {
-                      memory: '1Gi',
-                    },
-                    requests: {
-                      cpu: '500m',
-                      memory: '200Mi',
-                    },
+              containers: [{
+                name: 'istio-proxy',
+                resources: {
+                  limits: {
+                    memory: '1Gi',
                   },
-                }],
+                  requests: {
+                    cpu: '500m',
+                    memory: '200Mi',
+                  },
+                },
+              }],
             },
           },
         },
@@ -1162,7 +1194,7 @@ local environment = std.extVar('environment');
         'service.beta.kubernetes.io/aws-load-balancer-scheme': 'internet-facing',
       },
     },
-    spec+: {    
+    spec+: {
       gatewayClassName: 'istio',
     },
   },

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -52,10 +52,12 @@ assert sm.spec.endpoints[0].targetPort == 'metrics';
 assert sm.spec.endpoints[0].honorLabels == true;
 // interval defaults to 30s
 assert sm.spec.endpoints[0].interval == '30s';
-// default scrape-interval label is stamped on every series
-assert sm.spec.metricRelabelings == [
+// default scrape-interval label is stamped on the endpoint (spec-level
+// metricRelabelings does not exist in the ServiceMonitor CRD)
+assert sm.spec.endpoints[0].metricRelabelings == [
   { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
 ];
+assert !std.objectHas(sm.spec, 'metricRelabelings');
 // all Service labels are copied onto the series (not filtered)
 assert sm.spec.targetLabels == ['app', 'name', 'repo', 'reporting_team'];
 // selector matches only the Service identity, not the full label set
@@ -64,9 +66,14 @@ assert sm.spec.selector.matchLabels == { name: 'test' };
 assert !std.objectHas(sm.metadata.labels, 'monitoring.outreach.io/otel-scrape');
 assert !std.objectHas(sm.metadata.labels, 'prometheus.io/scrape');
 
-// interval is overridable via the constructor arg
+// interval is overridable via the constructor arg and reflected in the stamp
 local smInterval = k.ServiceMonitor('test', 'test', interval='60s') { target_service:: svc };
 assert smInterval.spec.endpoints[0].interval == '60s';
+assert smInterval.spec.endpoints[0].metricRelabelings[0].replacement == '60';
+
+// minute-based intervals convert to whole seconds
+local smMinute = k.ServiceMonitor('test', 'test', interval='2m') { target_service:: svc };
+assert smMinute.spec.endpoints[0].metricRelabelings[0].replacement == '120';
 
 // single-port service with no 'metrics' port falls back to that sole port
 // (apps serving /metrics on their only port, e.g. via endpoints_ override).
@@ -81,15 +88,19 @@ local smSinglePort = k.ServiceMonitor('test', 'test') {
 assert std.length(smSinglePort.spec.endpoints) == 1;
 assert smSinglePort.spec.endpoints[0].targetPort == 'http';
 assert smSinglePort.spec.endpoints[0].interval == '15s';
+// per-endpoint interval override is reflected in the stamp
+assert smSinglePort.spec.endpoints[0].metricRelabelings[0].replacement == '15';
 
-// metricRelabelings_+:: adds/replaces rules in the hidden map.
+// per-endpoint metricRelabelings pass through via endpoints_, appended after
+// the interval stamp.
 local smRelabel = k.ServiceMonitor('test', 'test') {
   target_service:: svc,
-  spec+: { metricRelabelings_+:: { drop_team: { regex: 'team', action: 'drop' } } },
+  spec+: { endpoints_+:: { metrics+: { metricRelabelings: [{ regex: 'team', action: 'drop' }] } } },
 };
-assert std.length(smRelabel.spec.metricRelabelings) == 2;
-assert std.member(smRelabel.spec.metricRelabelings, { targetLabel: 'outreach_metric_collection_interval', replacement: '30' });
-assert std.member(smRelabel.spec.metricRelabelings, { regex: 'team', action: 'drop' });
+assert smRelabel.spec.endpoints[0].metricRelabelings == [
+  { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
+  { regex: 'team', action: 'drop' },
+];
 
 // PodMonitor: metrics-port discovery from container ports, defaults, hooks.
 // Stencil-shaped pod: metrics container port is named 'http-prom' (not 'metrics').
@@ -109,18 +120,22 @@ assert pm.spec.podMetricsEndpoints[0].port == 'http-prom';
 assert pm.spec.podMetricsEndpoints[0].honorLabels == true;
 // interval defaults to 30s
 assert pm.spec.podMetricsEndpoints[0].interval == '30s';
-assert pm.spec.metricRelabelings == [
+// default scrape-interval label is stamped on the endpoint (spec-level
+// metricRelabelings does not exist in the PodMonitor CRD)
+assert pm.spec.podMetricsEndpoints[0].metricRelabelings == [
   { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
 ];
+assert !std.objectHas(pm.spec, 'metricRelabelings');
 // all pod labels are copied onto the series (not filtered)
 assert pm.spec.podTargetLabels == ['app', 'name', 'repo', 'reporting_team'];
 assert pm.spec.selector.matchLabels == { name: 'test' };
 // no scrape marker label (TA selector is open)
 assert !std.objectHas(pm.metadata.labels, 'monitoring.outreach.io/otel-scrape');
 
-// interval is overridable via the constructor arg
+// interval is overridable via the constructor arg and reflected in the stamp
 local pmInterval = k.PodMonitor('test', 'test', interval='60s') { target_pod:: podTmpl };
 assert pmInterval.spec.podMetricsEndpoints[0].interval == '60s';
+assert pmInterval.spec.podMetricsEndpoints[0].metricRelabelings[0].replacement == '60';
 
 // single-port pod with no metrics-named port falls back to that sole port.
 local pmSingle = k.PodMonitor('test', 'test') {
@@ -131,13 +146,15 @@ local pmSingle = k.PodMonitor('test', 'test') {
 };
 assert pmSingle.spec.podMetricsEndpoints[0].port == 'web';
 
-// metricRelabelings_+:: adds/replaces rules in the hidden map.
+// per-endpoint metricRelabelings pass through via podMetricsEndpoints_,
+// appended after the interval stamp.
 local pmRelabel = k.PodMonitor('test', 'test') {
   target_pod:: podTmpl,
-  spec+: { metricRelabelings_+:: { drop_team: { regex: 'team', action: 'drop' } } },
+  spec+: { podMetricsEndpoints_+:: { 'http-prom': { metricRelabelings: [{ regex: 'team', action: 'drop' }] } } },
 };
-assert std.length(pmRelabel.spec.metricRelabelings) == 2;
-assert std.member(pmRelabel.spec.metricRelabelings, { targetLabel: 'outreach_metric_collection_interval', replacement: '30' });
-assert std.member(pmRelabel.spec.metricRelabelings, { regex: 'team', action: 'drop' });
+assert pmRelabel.spec.podMetricsEndpoints[0].metricRelabelings == [
+  { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
+  { regex: 'team', action: 'drop' },
+];
 
 resources

--- a/tests/kube.jsonnet
+++ b/tests/kube.jsonnet
@@ -31,7 +31,10 @@ assert resources.deployment.spec.template.spec.containers_.test.envFrom[1].secre
 // ServiceMonitor: metrics-port discovery, defaults, and relabelings.
 local svc = {
   metadata: { name: 'test', namespace: 'test', labels: {
-    name: 'test', app: 'test', repo: 'test', reporting_team: 'fnd-pc',
+    name: 'test',
+    app: 'test',
+    repo: 'test',
+    reporting_team: 'fnd-pc',
   } },
   spec: { ports: [
     { name: 'grpc', port: 5000, targetPort: 'grpc' },
@@ -49,8 +52,10 @@ assert sm.spec.endpoints[0].targetPort == 'metrics';
 assert sm.spec.endpoints[0].honorLabels == true;
 // interval defaults to 30s
 assert sm.spec.endpoints[0].interval == '30s';
-// no relabelings by default -> key omitted (clean output)
-assert !std.objectHas(sm.spec.endpoints[0], 'metricRelabelings');
+// default scrape-interval label is stamped on every series
+assert sm.spec.metricRelabelings == [
+  { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
+];
 // all Service labels are copied onto the series (not filtered)
 assert sm.spec.targetLabels == ['app', 'name', 'repo', 'reporting_team'];
 // selector matches only the Service identity, not the full label set
@@ -77,14 +82,14 @@ assert std.length(smSinglePort.spec.endpoints) == 1;
 assert smSinglePort.spec.endpoints[0].targetPort == 'http';
 assert smSinglePort.spec.endpoints[0].interval == '15s';
 
-// per-endpoint metricRelabelings pass through via endpoints_.
+// metricRelabelings_+:: adds/replaces rules in the hidden map.
 local smRelabel = k.ServiceMonitor('test', 'test') {
   target_service:: svc,
-  spec+: { endpoints_:: { metrics: { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
+  spec+: { metricRelabelings_+:: { drop_team: { regex: 'team', action: 'drop' } } },
 };
-assert smRelabel.spec.endpoints[0].metricRelabelings == [
-  { regex: 'team', action: 'keep' },
-];
+assert std.length(smRelabel.spec.metricRelabelings) == 2;
+assert std.member(smRelabel.spec.metricRelabelings, { targetLabel: 'outreach_metric_collection_interval', replacement: '30' });
+assert std.member(smRelabel.spec.metricRelabelings, { regex: 'team', action: 'drop' });
 
 // PodMonitor: metrics-port discovery from container ports, defaults, hooks.
 // Stencil-shaped pod: metrics container port is named 'http-prom' (not 'metrics').
@@ -104,7 +109,9 @@ assert pm.spec.podMetricsEndpoints[0].port == 'http-prom';
 assert pm.spec.podMetricsEndpoints[0].honorLabels == true;
 // interval defaults to 30s
 assert pm.spec.podMetricsEndpoints[0].interval == '30s';
-assert !std.objectHas(pm.spec.podMetricsEndpoints[0], 'metricRelabelings');
+assert pm.spec.metricRelabelings == [
+  { targetLabel: 'outreach_metric_collection_interval', replacement: '30' },
+];
 // all pod labels are copied onto the series (not filtered)
 assert pm.spec.podTargetLabels == ['app', 'name', 'repo', 'reporting_team'];
 assert pm.spec.selector.matchLabels == { name: 'test' };
@@ -117,18 +124,20 @@ assert pmInterval.spec.podMetricsEndpoints[0].interval == '60s';
 
 // single-port pod with no metrics-named port falls back to that sole port.
 local pmSingle = k.PodMonitor('test', 'test') {
-  target_pod:: { metadata: { labels: { name: 'test', app: 'test' } },
-                 spec: { containers: [{ name: 'c', ports: [{ name: 'web', containerPort: 9000 }] }] } },
+  target_pod:: {
+    metadata: { labels: { name: 'test', app: 'test' } },
+    spec: { containers: [{ name: 'c', ports: [{ name: 'web', containerPort: 9000 }] }] },
+  },
 };
 assert pmSingle.spec.podMetricsEndpoints[0].port == 'web';
 
-// per-endpoint metricRelabelings pass through via podMetricsEndpoints_.
+// metricRelabelings_+:: adds/replaces rules in the hidden map.
 local pmRelabel = k.PodMonitor('test', 'test') {
   target_pod:: podTmpl,
-  spec+: { podMetricsEndpoints_+:: { 'http-prom': { metricRelabelings: [{ regex: 'team', action: 'keep' }] } } },
+  spec+: { metricRelabelings_+:: { drop_team: { regex: 'team', action: 'drop' } } },
 };
-assert pmRelabel.spec.podMetricsEndpoints[0].metricRelabelings == [
-  { regex: 'team', action: 'keep' },
-];
+assert std.length(pmRelabel.spec.metricRelabelings) == 2;
+assert std.member(pmRelabel.spec.metricRelabelings, { targetLabel: 'outreach_metric_collection_interval', replacement: '30' });
+assert std.member(pmRelabel.spec.metricRelabelings, { regex: 'team', action: 'drop' });
 
 resources


### PR DESCRIPTION
Adds default metricRelabelings that stamp outreach_metric_collection_interval (numeric seconds) on every scraped series by ServiceMonitor and PodMonitor.\n\nThis lets downstream OTel collectors attach collection-interval metadata at the resource level for correct query sample-rate normalization.